### PR TITLE
Fix for data directory copied to wrong directory

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -73,17 +73,17 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         # Collect all files in the data directory recursively
         collect_data_files(DATA_FILES "${CMAKE_CURRENT_SOURCE_DIR}/data")
 
-        # Create a stamp file to mark the copy operation, placed in the config-specific output directory
-        set(DATA_STAMP "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIG>/data_copied.stamp")
+        # Create a stamp file to mark the copy operation, placed in the output directory
+        set(DATA_STAMP "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/data_copied.stamp")
 
         add_custom_command(
             OUTPUT ${DATA_STAMP}
             COMMAND ${CMAKE_COMMAND} -E copy_directory
                     ${CMAKE_CURRENT_SOURCE_DIR}/data
-                    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIG>/data
+                    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/data
             COMMAND ${CMAKE_COMMAND} -E touch ${DATA_STAMP}
             DEPENDS ${DATA_FILES}
-            COMMENT "Copying data folder to ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIG>/data"
+            COMMENT "Copying data folder to ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/data"
         )
 
         # Add a custom target to depend on the stamp file


### PR DESCRIPTION
On windows, the example project file is set to use the working directory in build/bin
The readme file also says
`When running the example or test, the working directory should be the the binary direction (/build/bin). On Windows, the example data direction is copied there and on Linux or macOS there's a symlink for the data directory.`

The example cmake file, however, copies the data directory to a config specific sub-directory of /build/bin, such as /build/bin/Debug or /build/bin/Release.

This PR fixes this inconsistency, by copying the data directory to /build/bin instead ..

An alternative could be to make the workdirectory point to the config specific sub-directory & adjust the readme text?
( issue #41 )
