### PR TITLE
fix for skb__get_next_grapheme_pos not setting text_offset

### DIFF
--- a/src/skb_editor.c
+++ b/src/skb_editor.c
@@ -572,6 +572,8 @@ static skb__editor_text_position_t skb__get_next_grapheme_pos(const skb_editor_t
 		}
 	}
 
+	edit_pos.text_offset = paragraph->text_start_offset + edit_pos.paragraph_offset;
+
 	return edit_pos;
 }
 
@@ -601,6 +603,8 @@ static skb__editor_text_position_t skb__get_prev_grapheme_pos(const skb_editor_t
 			break;
 		}
 	}
+
+	edit_pos.text_offset = paragraph->text_start_offset + edit_pos.paragraph_offset;
 
 	return edit_pos;
 }


### PR DESCRIPTION
skb__get_next_grapheme_pos/skb__get_prev_grapheme_pos didn't set text_offset, only paragraph_offset

this caused some issues when recording undo when pressing delete (issue #46 ), since the begin and end range of the character to be deleted was 0 in size