### PR TITLE
Add Gtk-based Linux implementation to IME example.

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -46,9 +46,38 @@ set_target_properties(skribidi_example PROPERTIES
 target_include_directories(skribidi_example PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${GLAD_DIR}/include)
 target_link_libraries(skribidi_example PUBLIC glfw skribidi harfbuzz)
 
-# IME only works on Windows for now.
-if(MSVC)
+if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     target_link_libraries(skribidi_example PUBLIC imm32.lib comctl32.lib)
+elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    message(STATUS "Detecting GTK for IME support on Linux")
+    find_package(PkgConfig REQUIRED)
+    # Try GTK3, fallback to GTK4
+    pkg_check_modules(GTK_REQ gtk+-3.0)
+    if (GTK_REQ_FOUND)
+        set(GTK_PKG gtk+-3.0)
+    else()
+        pkg_check_modules(GTK_REQ gtk4)
+        if (GTK_REQ_FOUND)
+            set(GTK_PKG gtk4)
+        else()
+            message(FATAL_ERROR "Neither gtk+-3.0 nor gtk4 found. Please install GTK.")
+        endif()
+    endif()
+
+    message(STATUS "Using ${GTK_PKG} for IME support")
+    pkg_check_modules(GTK ${GTK_PKG})
+
+    target_include_directories(skribidi_example
+        PRIVATE ${GTK_INCLUDE_DIRS}
+    )
+    target_link_libraries(skribidi_example
+        PUBLIC ${GTK_LIBRARIES}
+    )
+    target_compile_options(skribidi_example
+        PRIVATE ${GTK_CFLAGS_OTHER}
+    )
+elseif (APPLE)
+    message(WARNING "IME support not implemented for Apple platforms")
 endif()
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SKRIBIDI_EXAMPLE_FILES})

--- a/example/ime.c
+++ b/example/ime.c
@@ -3,9 +3,12 @@
 
 #include "ime.h"
 #include "skb_common.h"
+#include <stddef.h>
+#include <stdio.h>
+
+#include <GLFW/glfw3.h>
 
 #ifdef _WIN32
-#include <GLFW/glfw3.h>
 #define GLFW_EXPOSE_NATIVE_WIN32
 #include <GLFW/glfw3native.h>
 #include <windows.h>
@@ -234,6 +237,161 @@ bool ime_init(GLFWwindow* window)
 
 void ime_terminate(void)
 {
+	skb_free(g_context.preedit_text);
+	memset(&g_context, 0, sizeof(g_context));
+}
+
+#elif defined(__linux__)
+
+#define GLFW_EXPOSE_NATIVE_X11
+#include <GLFW/glfw3native.h>
+#include <gtk/gtk.h>
+
+#if GTK_MAJOR_VERSION == 3 && defined(GDK_WINDOWING_X11)
+#  include <gdk/gdkx.h>
+#  include <X11/Xlib.h>
+#endif
+
+typedef struct ime_context_t {
+	GtkIMContext      *im;
+	uint32_t          *preedit_text;
+	int32_t            preedit_text_cap;
+	int32_t            preedit_text_count;
+	int32_t            caret_position;
+	skb_rect2i_t       input_rect;
+	bool               is_composing;
+	ime_event_handler_func_t *handler;
+	void              *handler_context;
+} ime_context_t;
+
+static ime_context_t g_context = {0};
+
+// Helper: copy UTF-8 string into UTF-32 buffer
+static void ime__copy_utf8(const char* utf8)
+{
+	int32_t len8 = (int32_t)strlen(utf8);
+	int32_t need32 = skb_utf8_to_utf32_count(utf8, len8);
+	SKB_ARRAY_RESERVE(g_context.preedit_text, need32+1);
+	g_context.preedit_text_count = skb_utf8_to_utf32(utf8, len8, g_context.preedit_text, need32);
+	g_context.preedit_text[need32] = 0;
+}
+
+// Signal: commit finalized text
+static void on_commit(GtkIMContext *ctx, const char *str, gpointer user)
+{
+	(void)ctx; (void)user;
+	ime__copy_utf8(str);
+	g_context.is_composing = false;
+	if (g_context.handler)
+		g_context.handler(IME_EVENT_COMMIT,
+						  g_context.preedit_text,
+						  g_context.preedit_text_count,
+						  g_context.caret_position,
+						  g_context.handler_context);
+}
+
+// Signal: preedit (composition) changed
+static void on_preedit_changed(GtkIMContext *ctx, gpointer user)
+{
+	(void)ctx; (void)user;
+	char *pre = NULL;
+	int cursor8 = 0;
+	gtk_im_context_get_preedit_string(ctx, &pre, NULL, &cursor8);
+
+	ime__copy_utf8(pre);
+	// convert cursor offset UTF-8->UTF-32
+	g_context.caret_position = skb_utf8_to_utf32_count(pre, cursor8);
+	g_context.is_composing = true;
+
+	if (g_context.handler)
+		g_context.handler(IME_EVENT_COMPOSITION,
+						  g_context.preedit_text,
+						  g_context.preedit_text_count,
+						  g_context.caret_position,
+						  g_context.handler_context);
+	g_free(pre);
+}
+
+// Signals: start & end composition
+static void on_preedit_start(GtkIMContext *ctx, gpointer user)  { (void)ctx; (void)user; g_context.is_composing = true; }
+static void on_preedit_end  (GtkIMContext *ctx, gpointer user)
+{
+	(void)ctx; (void)user;
+	g_context.is_composing = false;
+	if (g_context.handler)
+		g_context.handler(IME_EVENT_CANCEL, NULL, 0, 0, g_context.handler_context);
+}
+
+bool ime_init(GLFWwindow* window)
+{
+	// Initialise GTK once, if the host app hasn't done so
+	static bool gtk_ok = false;
+	static bool gtk_checked = false;
+	if (!gtk_checked) {
+		gtk_ok = gtk_init_check(NULL, NULL);   // returns FALSE if no DISPLAY
+		gtk_checked = true;
+	}
+	if (!gtk_ok)
+		return false;
+
+	g_context.im = gtk_im_multicontext_new();
+	if (!g_context.im)
+		return false;
+
+  // On X11 we need to bind the IM context to the GLFW window's GdkWindow
+#if defined(GDK_WINDOWING_X11)
+	Window xid = glfwGetX11Window(window);
+	GdkDisplay* disp = gdk_display_get_default();
+	GdkWindow* gw = gdk_x11_window_foreign_new_for_display(disp, xid);
+	gtk_im_context_set_client_window(g_context.im, gw);
+
+	/* --- debug: print --- */
+	g_print("Binding IM context to GdkWindow %p for XID 0x%lx\n", (void*)gw, xid);
+	gint gw_x, gw_y, gw_width, gw_height;
+	gdk_window_get_geometry(gw,
+							&gw_x, &gw_y,
+							&gw_width, &gw_height);
+	g_print("GdkWindow %p (XID 0x%lx) geometry: x=%d, y=%d, w=%d, h=%d\n",
+			(void*)gw, xid,
+			gw_x, gw_y,
+			gw_width, gw_height);
+#endif
+
+	g_signal_connect(g_context.im, "commit", G_CALLBACK(on_commit), NULL);
+	g_signal_connect(g_context.im, "preedit-changed", G_CALLBACK(on_preedit_changed), NULL);
+	g_signal_connect(g_context.im, "preedit-start", G_CALLBACK(on_preedit_start), NULL);
+	g_signal_connect(g_context.im, "preedit-end", G_CALLBACK(on_preedit_end), NULL);
+
+	return true;
+}
+
+void ime_set_handler(ime_event_handler_func_t* handler, void* context)
+{
+	g_context.handler = handler;
+	g_context.handler_context = context;
+}
+
+void ime_set_input_rect(skb_rect2i_t rect)
+{
+	printf("ime_set_input_rect %d %d %d %d\n", rect.x, rect.y, rect.width, rect.height);
+	g_context.input_rect = rect;
+	if (g_context.im) {
+		GdkRectangle r = { rect.x, rect.y, rect.width, rect.height };
+		gtk_im_context_set_cursor_location(g_context.im, &r);
+	}
+}
+
+void ime_cancel(void)
+{
+	if (g_context.im)
+		gtk_im_context_reset(g_context.im);
+	g_context.is_composing = false;
+}
+
+void ime_terminate(void)
+{
+	if (g_context.im)
+		g_object_unref(g_context.im);
 	skb_free(g_context.preedit_text);
 	memset(&g_context, 0, sizeof(g_context));
 }


### PR DESCRIPTION
This is an attempt at adding Gtk-based IME support to the example.

While it kinda works, the IME overlay window always ends up displayed outside the main display window.
I think this is due to creating a Gdk dummy window from the GLFW window, even though I've confirmed the window ends up with correct geometry size and position, I can't get the actual IME overlay to be positioned inside the window.

I've tried a standalone Gtk IME minimal example and it works as expected there.

So I am not sure if its worth it to merge this, but decided to share anyway, maybe you have some other ideas.

There is also https://github.com/glfw/glfw/pull/2130, maybe that's the way to go for a cross-platform example?