### PR TITLE
Reworked how attributes work

### DIFF
--- a/example/example_richtext.c
+++ b/example/example_richtext.c
@@ -111,7 +111,32 @@ void* richtext_create(void)
 		.baseline = SKB_BASELINE_MIDDLE,
 	};
 
-	skb_text_attribs_t attribs_small = {
+	const skb_attribute_t attributes_small[] = {
+		skb_attribute_make_font(SKB_FONT_FAMILY_DEFAULT, 15.f, SKB_WEIGHT_NORMAL, SKB_STYLE_NORMAL, SKB_STRETCH_NORMAL),
+		skb_attribute_make_fill(ink_color),
+	};
+
+	const skb_attribute_t attributes_italic[] = {
+		skb_attribute_make_font(SKB_FONT_FAMILY_DEFAULT, 64.f, SKB_WEIGHT_NORMAL, SKB_STYLE_ITALIC, SKB_STRETCH_NORMAL),
+		skb_attribute_make_fill(ink_color),
+		skb_attribute_make_spacing(20.f, 0.f),
+	};
+
+	const skb_attribute_t attributes_big[] = {
+		skb_attribute_make_font(SKB_FONT_FAMILY_DEFAULT, 128.f, SKB_WEIGHT_BOLD, SKB_STYLE_NORMAL, SKB_STRETCH_NORMAL),
+		skb_attribute_make_fill(skb_rgba(220,40,40,255)),
+	};
+
+	const skb_attribute_t attributes_fracts[] = {
+		skb_attribute_make_font(SKB_FONT_FAMILY_DEFAULT, 48.f, SKB_WEIGHT_BOLD, SKB_STYLE_NORMAL, SKB_STRETCH_NORMAL),
+		skb_attribute_make_fill(skb_rgba(180,110,190,255)),
+		skb_attribute_make_font_feature(SKB_TAG_STR("frac"), 1),
+		skb_attribute_make_font_feature(SKB_TAG_STR("numr"), 1),
+		skb_attribute_make_font_feature(SKB_TAG_STR("dmon"), 1),
+	};
+
+
+/*	skb_text_attribs_t attribs_small = {
 		.font_size = 15.f,
 		.font_weight = SKB_WEIGHT_NORMAL,
 		.line_spacing_multiplier = 1.f, //1.3f,
@@ -145,7 +170,7 @@ void* richtext_create(void)
 		.color = skb_rgba(180,110,190,255),
 		.font_features = frac_features,
 		.font_features_count = SKB_COUNTOF(frac_features),
-	};
+	};*/
 
 	const char* ipsum =
 		"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam eget blandit purus, sit amet faucibus quam. Morbi vulputate tellus in nulla fermentum feugiat id eu diam. Sed id orci sapien. "
@@ -160,14 +185,14 @@ void* richtext_create(void)
 		"Nunc blandit molestie neque, quis porttitor lectus. Pellentesque consectetur augue sed velit suscipit pretium. In nec massa eros. Fusce non justo efficitur metus auctor pretium efficitur mattis enim.\n";
 
 	skb_text_run_utf8_t runs[] = {
-		{ ipsum, -1, &attribs_small },
-		{ "moikkelis!\n", -1, &attribs_italic },
-		{ "این یک 😬👀🚨 تست است\n", -1, &attribs_small },
-		{ "ہے۔ kofi یہ ایک\n", -1, &attribs_small },
-		{ "POKS! 🧁\n", -1, &attribs_big },
-		{ "11/17\n", -1, &attribs_fracts },
-		{ "शकति शक्ति ", -1, &attribs_italic },
-		{ "今天天气晴朗。 ", -1, &attribs_small },
+		{ ipsum, -1, attributes_small, SKB_COUNTOF(attributes_small) },
+		{ "moikkelis!\n", -1, attributes_italic, SKB_COUNTOF(attributes_italic) },
+		{ "این یک 😬👀🚨 تست است\n", -1, attributes_small, SKB_COUNTOF(attributes_small) },
+		{ "ہے۔ kofi یہ ایک\n", -1, attributes_small, SKB_COUNTOF(attributes_small) },
+		{ "POKS! 🧁\n", -1, attributes_big, SKB_COUNTOF(attributes_big) },
+		{ "11/17\n", -1, attributes_fracts, SKB_COUNTOF(attributes_fracts) },
+		{ "शकति शक्ति ", -1, attributes_italic, SKB_COUNTOF(attributes_italic) },
+		{ "今天天气晴朗。 ", -1, attributes_small, SKB_COUNTOF(attributes_small) },
 	};
 
 	ctx->layout = skb_layout_create_from_runs_utf8(ctx->temp_alloc, &params, runs, SKB_COUNTOF(runs));
@@ -296,7 +321,7 @@ void richtext_on_update(void* ctx_ptr, int32_t view_width, int32_t view_height)
 		// Draw layout
 		const skb_glyph_t* glyphs = skb_layout_get_glyphs(ctx->layout);
 		const int32_t glyphs_count = skb_layout_get_glyphs_count(ctx->layout);
-		const skb_text_attribs_span_t* attrib_spans = skb_layout_get_attribute_spans(ctx->layout);
+		const skb_text_attributes_span_t* attrib_spans = skb_layout_get_attribute_spans(ctx->layout);
 		const skb_layout_params_t* layout_params = skb_layout_get_params(ctx->layout);
 
 		if (ctx->show_glyph_bounds) {
@@ -310,7 +335,9 @@ void richtext_on_update(void* ctx_ptr, int32_t view_width, int32_t view_height)
 		skb_font_handle_t font_handle = 0;
 		uint16_t span_idx = 0;
 		while (skb_glyph_run_iterator_next(&glyph_iter, &glyph_range, &font_handle, &span_idx)) {
-			const skb_text_attribs_span_t* span = &attrib_spans[span_idx];
+			const skb_text_attributes_span_t* span = &attrib_spans[span_idx];
+			const skb_attribute_fill_t attr_fill = skb_attributes_get_fill(span->attributes, span->attributes_count);
+			const skb_attribute_font_t attr_font = skb_attributes_get_font(span->attributes, span->attributes_count);
 			for (int32_t gi = glyph_range.start; gi < glyph_range.end; gi++) {
 				const skb_glyph_t* glyph = &glyphs[gi];
 
@@ -320,7 +347,7 @@ void richtext_on_update(void* ctx_ptr, int32_t view_width, int32_t view_height)
 				if (ctx->show_glyph_bounds) {
 					draw_tick(view_transform_x(&ctx->view,gx), view_transform_y(&ctx->view,gy), 5.f, ink_color_trans);
 
-					skb_rect2_t bounds = skb_font_get_glyph_bounds(layout_params->font_collection, font_handle, glyph->gid, span->attribs.font_size);
+					skb_rect2_t bounds = skb_font_get_glyph_bounds(layout_params->font_collection, font_handle, glyph->gid, attr_font.size);
 					bounds.x += gx;
 					bounds.y += gy;
 					bounds = view_transform_rect(&ctx->view, bounds);
@@ -331,11 +358,11 @@ void richtext_on_update(void* ctx_ptr, int32_t view_width, int32_t view_height)
 				skb_render_quad_t quad = skb_render_cache_get_glyph_quad(
 					ctx->render_cache,gx, gy, ctx->view.scale,
 					layout_params->font_collection, font_handle, glyph->gid,
-					span->attribs.font_size, SKB_RENDER_ALPHA_SDF);
+					attr_font.size, SKB_RENDER_ALPHA_SDF);
 
 				draw_image_quad_sdf(
 					view_transform_rect(&ctx->view, quad.geom_bounds),
-					quad.image_bounds, 1.f / quad.scale, (quad.flags & SKB_RENDER_QUAD_IS_COLOR) ? skb_rgba(255,255,255, span->attribs.color.a) : span->attribs.color,
+					quad.image_bounds, 1.f / quad.scale, (quad.flags & SKB_RENDER_QUAD_IS_COLOR) ? skb_rgba(255,255,255, attr_fill.color.a) : attr_fill.color,
 					(uint32_t)skb_render_cache_get_image_user_data(ctx->render_cache, quad.image_idx));
 			}
 		}

--- a/example/example_testbed.c
+++ b/example/example_testbed.c
@@ -193,6 +193,18 @@ void* testbed_create(void)
 
 	skb_color_t ink_color = skb_rgba(64,64,64,255);
 
+	const skb_attribute_t attributes[] = {
+		skb_attribute_make_font(SKB_FONT_FAMILY_DEFAULT, 92.f, SKB_WEIGHT_NORMAL, SKB_STYLE_NORMAL, SKB_STRETCH_NORMAL),
+		skb_attribute_make_line_height(1.3f),
+		skb_attribute_make_fill(ink_color),
+	};
+
+	const skb_attribute_t composition_attributes[] = {
+		skb_attribute_make_font(SKB_FONT_FAMILY_DEFAULT, 92.f, SKB_WEIGHT_NORMAL, SKB_STYLE_NORMAL, SKB_STRETCH_NORMAL),
+		skb_attribute_make_line_height(1.3f),
+		skb_attribute_make_fill(skb_rgba(0,128,192,255)),
+	};
+
 	skb_editor_params_t edit_params = {
 		.layout_params = {
 			.lang = "zh-hans",
@@ -200,16 +212,10 @@ void* testbed_create(void)
 			.font_collection = ctx->font_collection,
 			.line_break_width = 1200.f,
 		},
-		.text_attribs = {
-			.font_size = 92.f,
-			.line_spacing_multiplier = 1.3f,
-			.color = ink_color,
-		},
-		.composition_text_attribs = {
-			.font_size = 92.f,
-			.line_spacing_multiplier = 1.3f,
-			.color = skb_rgba(0,128,192,255),
-		},
+		.text_attributes = attributes,
+		.text_attributes_count = SKB_COUNTOF(attributes),
+		.composition_attributes = composition_attributes,
+		.composition_attributes_count = SKB_COUNTOF(composition_attributes),
 	};
 
 	ctx->editor = skb_editor_create(&edit_params);
@@ -504,7 +510,7 @@ void testbed_on_update(void* ctx_ptr, int32_t view_width, int32_t view_height)
 			const int32_t lines_count = skb_layout_get_lines_count(edit_layout);
 			const skb_glyph_t* glyphs = skb_layout_get_glyphs(edit_layout);
 			const int32_t glyphs_count = skb_layout_get_glyphs_count(edit_layout);
-			const skb_text_attribs_span_t* attrib_spans = skb_layout_get_attribute_spans(edit_layout);
+			const skb_text_attributes_span_t* attrib_spans = skb_layout_get_attribute_spans(edit_layout);
 			const skb_layout_params_t* layout_params = skb_layout_get_params(edit_layout);
 
 			for (int li = 0; li < lines_count; li++) {
@@ -537,7 +543,9 @@ void testbed_on_update(void* ctx_ptr, int32_t view_width, int32_t view_height)
 				skb_font_handle_t font_handle = 0;
 				uint16_t span_idx = 0;
 				while (skb_glyph_run_iterator_next(&glyph_iter, &glyph_range, &font_handle, &span_idx)) {
-					const skb_text_attribs_span_t* span = &attrib_spans[span_idx];
+					const skb_text_attributes_span_t* span = &attrib_spans[span_idx];
+					const skb_attribute_fill_t attr_fill = skb_attributes_get_fill(span->attributes, span->attributes_count);
+					const skb_attribute_font_t attr_font = skb_attributes_get_font(span->attributes, span->attributes_count);
 					for (int32_t gi = glyph_range.start; gi < glyph_range.end; gi++) {
 						const skb_glyph_t* glyph = &glyphs[gi];
 
@@ -549,7 +557,7 @@ void testbed_on_update(void* ctx_ptr, int32_t view_width, int32_t view_height)
 							draw_tick(gx, gy, 5.f, ink_color_trans);
 
 							// Glyph bounds
-							skb_rect2_t bounds = skb_font_get_glyph_bounds(layout_params->font_collection, glyph->font_handle, glyph->gid, span->attribs.font_size);
+							skb_rect2_t bounds = skb_font_get_glyph_bounds(layout_params->font_collection, glyph->font_handle, glyph->gid, attr_font.size);
 							draw_rect(gx + bounds.x, gy + bounds.y, bounds.width, bounds.height, ink_color_trans);
 
 							// Visual index
@@ -564,9 +572,9 @@ void testbed_on_update(void* ctx_ptr, int32_t view_width, int32_t view_height)
 						skb_render_quad_t quad = skb_render_cache_get_glyph_quad(ctx->render_cache,
 							skb_roundf(gx), skb_roundf(gy), 1.f,
 							layout_params->font_collection, glyph->font_handle, glyph->gid,
-							span->attribs.font_size, SKB_RENDER_ALPHA_SDF);
+							attr_font.size, SKB_RENDER_ALPHA_SDF);
 
-						draw_image_quad_sdf(quad.geom_bounds, quad.image_bounds, quad.scale, (quad.flags & SKB_RENDER_QUAD_IS_COLOR) ? skb_rgba(255,255,255,255) : span->attribs.color,
+						draw_image_quad_sdf(quad.geom_bounds, quad.image_bounds, quad.scale, (quad.flags & SKB_RENDER_QUAD_IS_COLOR) ? skb_rgba(255,255,255,255) : attr_fill.color,
 							(uint32_t)skb_render_cache_get_image_user_data(ctx->render_cache, quad.image_idx));
 
 						pen_x += glyph->advance_x;
@@ -705,11 +713,12 @@ void testbed_on_update(void* ctx_ptr, int32_t view_width, int32_t view_height)
 	// Draw logical string info
 	{
 		const skb_editor_params_t* edit_params = skb_editor_get_params(ctx->editor);
-		const skb_text_attribs_t* text_attribs = &edit_params->text_attribs;
+		const skb_attribute_font_t attr_font = skb_attributes_get_font(edit_params->text_attributes, edit_params->text_attributes_count);
+//		const skb_text_attribs_t* text_attribs = &edit_params->text_attributes;
 		float ox = ctx->view.cx;
 		float oy = ctx->view.cy + 30.f + layout_height + 80.f;
 		float sz = 80.f;
-		float font_scale = (sz * 0.5f) / text_attribs->font_size;
+		float font_scale = (sz * 0.5f) / attr_font.size;
 
 		bool prev_is_emoji = false;
 		uint8_t prev_script = 0;
@@ -785,9 +794,9 @@ void testbed_on_update(void* ctx_ptr, int32_t view_width, int32_t view_height)
 
 					const uint8_t script = text_props[cp_idx].script;
 					const bool is_emoji = (text_props[cp_idx].flags & SKB_TEXT_PROP_EMOJI);
-					const uint8_t font_family = is_emoji ? SKB_FONT_FAMILY_EMOJI : text_attribs->font_family;
+					const uint8_t font_family = is_emoji ? SKB_FONT_FAMILY_EMOJI : attr_font.family;
 					if (!font_handle || script != prev_script || is_emoji != prev_is_emoji) {
-						if (skb_font_collection_match_fonts(ctx->font_collection, "", script, font_family, text_attribs->font_style, text_attribs->font_stretch, text_attribs->font_weight, &font_handle, 1) == 0)
+						if (skb_font_collection_match_fonts(ctx->font_collection, "", script, font_family, attr_font.weight, attr_font.style, attr_font.stretch, &font_handle, 1) == 0)
 							font_handle = 0;
 						prev_script = script;
 						prev_is_emoji = is_emoji;
@@ -804,7 +813,7 @@ void testbed_on_update(void* ctx_ptr, int32_t view_width, int32_t view_height)
 						hb_font_get_nominal_glyph(skb_font_get_hb_font(ctx->font_collection, font_handle), cp, &gid);
 
 						// Draw glyph centered on the rect.
-						skb_rect2_t bounds = skb_font_get_glyph_bounds(ctx->font_collection, font_handle, gid, text_attribs->font_size * font_scale);
+						skb_rect2_t bounds = skb_font_get_glyph_bounds(ctx->font_collection, font_handle, gid, attr_font.size * font_scale);
 
 						float base_line = oy + sz * 0.75f;
 						draw_line(ox+4+0.5f, base_line+0.5f, ox + sz - 4+0.5f, base_line+0.5f, log_color);
@@ -814,7 +823,7 @@ void testbed_on_update(void* ctx_ptr, int32_t view_width, int32_t view_height)
 
 						skb_render_quad_t quad = skb_render_cache_get_glyph_quad(ctx->render_cache,
 							skb_roundf(gx), skb_roundf(gy), 1.f,
-							ctx->font_collection,  font_handle, gid, text_attribs->font_size * font_scale, SKB_RENDER_ALPHA_MASK);
+							ctx->font_collection,  font_handle, gid, attr_font.size * font_scale, SKB_RENDER_ALPHA_MASK);
 
 						draw_image_quad(quad.geom_bounds, quad.image_bounds, (quad.flags & SKB_RENDER_QUAD_IS_COLOR) ? skb_rgba(255,255,255,255) : ink_color,
 							(uint32_t)skb_render_cache_get_image_user_data(ctx->render_cache, quad.image_idx));

--- a/include/skb_editor.h
+++ b/include/skb_editor.h
@@ -54,9 +54,13 @@ typedef struct skb_editor_params_t {
 	/** Layout parameters used for each paragraph layout. */
 	skb_layout_params_t layout_params;
 	/** Text attributes for all the text. */
-	skb_text_attribs_t text_attribs;
+	const skb_attribute_t* text_attributes;
+	/** Number of text attributes. */
+	int32_t text_attributes_count;
 	/** Text attributes for the IME composition text. */
-	skb_text_attribs_t composition_text_attribs;
+	const skb_attribute_t* composition_attributes;
+	/** Number of compositoin text attributes. */
+	int32_t composition_attributes_count;
 	/** Base direction of the text editor. */
 	uint8_t base_direction;
 	/** Care movement mode */
@@ -350,7 +354,7 @@ bool skb_editor_can_redo(skb_editor_t* editor);
  * @param temp_alloc temp allocator used to relayout the text.
  */
 void skb_editor_redo(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc);
-	
+
 /**
  * Sets temporary IME composition text as utf-32. The text will be laid out at the current cursor location.
  * The function can be called multiple times during while the user composes the input.

--- a/include/skb_font_collection.h
+++ b/include/skb_font_collection.h
@@ -238,9 +238,9 @@ skb_font_handle_t skb_font_collection_add_font_from_data(
  * @param lang the languages of the requested text.
  * @param script script to match.
  * @param font_family font family to match.
+ * @param weight weight to match.
  * @param style style to match.
  * @param stretch stretch to match.
- * @param weight weight to match.
  * @param results pointer to results array.
  * @param results_cap results array capacity.
  * @return number of fonts matching the parameters.
@@ -248,7 +248,7 @@ skb_font_handle_t skb_font_collection_add_font_from_data(
 int32_t skb_font_collection_match_fonts(
 	skb_font_collection_t* font_collection,
 	const char* lang, uint8_t script, uint8_t font_family,
-	skb_style_t style, skb_stretch_t stretch, skb_weight_t weight,
+	skb_weight_t weight, skb_style_t style, skb_stretch_t stretch,
 	skb_font_handle_t* results, int32_t results_cap);
 
 /**

--- a/include/skb_layout.h
+++ b/include/skb_layout.h
@@ -37,6 +37,168 @@ typedef const struct hb_language_impl_t *hb_language_t;
  * @{
  */
 
+//
+// Text attributes
+//
+
+/**
+ * Writing mode text attribute.
+ * If multiple writing attributes are defined, only the first one is used.
+ * Subset of https://drafts.csswg.org/css-writing-modes-4/
+ */
+typedef struct skb_attribute_writing_t {
+	/** BCP 47 language tag, e.g. fi-FI. If NULL, do not override language.  */
+	const char* lang;
+	/** Text writing direction, no change if SKB_DIRECTION_AUTO. */
+	uint8_t direction;
+} skb_attribute_writing_t;
+
+/**
+ * Font text attribute.
+ * If multiple font attributes are defined, only the first one is used.
+ * Subset of https://drafts.csswg.org/css-fonts/
+ */
+typedef struct skb_attribute_font_t {
+	/** Font size (px). Default 16.0 */
+	float size;
+	/** Font family, see skb_font_family_t. Default SKB_FONT_FAMILY_DEFAULT. */
+	uint8_t family;
+	/** Font weight, see skb_weight_t. Default SKB_WEIGHT_NORMAL. */
+	uint8_t weight;
+	/** Font style, see skb_style_t. Default SKB_STYLE_NORMAL. */
+	uint8_t style;
+	/** Font stretch see skb_stretch_t. Default SKB_STRETCH_NORMAL. */
+	uint8_t stretch;
+} skb_attribute_font_t;
+
+/**
+ * Font feature text attribute.
+ * The attribute array can contain multiple font feature attributes.
+ * See https://learn.microsoft.com/en-us/typography/opentype/spec/featuretags
+ */
+typedef struct skb_attribute_font_feature_t {
+	/** OpenType font feature tag */
+	uint32_t tag;
+	/** Taga value, often 1 = on, 0 = off. */
+	uint32_t value;
+} skb_attribute_font_feature_t;
+
+/**
+ * Text spacing attribute.
+ * If multiple spacing attributes are defined, only the first one is used.
+ * Subset of https://drafts.csswg.org/css-text/
+ */
+typedef struct skb_attribute_spacing_t {
+	/** Letter spacing (px)  */
+	float letter;
+	/** Word spacing (px) */
+	float word;
+} skb_attribute_spacing_t;
+
+/**
+ * Line height attribute.
+ * If multiple line height attributes are defined, only the first one is used.
+ */
+typedef struct skb_attribute_line_height_t {
+	/** Line spacing multiplier. */
+	float line_spacing_multiplier;
+} skb_attribute_line_height_t;
+
+/**
+ * Text fill color attribute.
+ * It is up to the client code to decide if multiple fill attributes are supported.
+ */
+typedef struct skb_attribute_fill_t {
+	/** Color of the text */
+	skb_color_t color;
+} skb_attribute_fill_t;
+
+/** Enum describing tags for each of the attributes. */
+typedef enum {
+	/** Tag for skb_attribute_writing_t */
+	SKB_ATTRIBUTE_WRITING = SKB_TAG('w','r','i','t'),
+	/** Tag for skb_attribute_font_t */
+	SKB_ATTRIBUTE_FONT = SKB_TAG('f','o','n','t'),
+	/** Tag for skb_attribute_font_feature_t */
+	SKB_ATTRIBUTE_FONT_FEATURE = SKB_TAG('f','e','a','t'),
+	/** tag for skb_attribute_spacing_t */
+	SKB_ATTRIBUTE_SPACING = SKB_TAG('s','p','c','e'),
+	/** Tag for skb_attribute_line_height_t */
+	SKB_ATTRIBUTE_LINE_HEIGHT = SKB_TAG('l','n','h','e'),
+	/** Tag for skb_attribute_fill_t */
+	SKB_ATTRIBUTE_FILL = SKB_TAG('f','i','l','l'),
+} skb_attribute_type_t;
+
+/**
+ * Tagged union struct which can hold any text attribute.
+ */
+typedef struct skb_attribute_t {
+	uint32_t type;
+	union {
+		skb_attribute_writing_t writing;
+		skb_attribute_font_t font;
+		skb_attribute_font_feature_t font_feature;
+		skb_attribute_spacing_t spacing;
+		skb_attribute_line_height_t line_height;
+		skb_attribute_fill_t fill;
+	};
+} skb_attribute_t;
+
+/** @returns new writing mode text attribute. See skb_attribute_writing_t */
+skb_attribute_t skb_attribute_make_writing(const char* lang, skb_text_direction_t direction);
+
+/** @returns new font text attribute. See skb_attribute_font_t */
+skb_attribute_t skb_attribute_make_font(skb_font_family_t family, float size, skb_weight_t weight, skb_style_t style, skb_stretch_t stretch);
+
+/** @returns new font feature text attribute. See skb_attribute_font_attribute_t */
+skb_attribute_t skb_attribute_make_font_feature(uint32_t tag, uint32_t value);
+
+/** @returns new spacing text attribute. See skb_attribute_spacing_t */
+skb_attribute_t skb_attribute_make_spacing(float letter, float word);
+
+/** @returns new line height text attribute. See skb_attribute_spacing_t */
+skb_attribute_t skb_attribute_make_line_height(float line_spacing_multiplier);
+
+/** @returns new fill color text attribute. See skb_attribute_spacing_t */
+skb_attribute_t skb_attribute_make_fill(skb_color_t color);
+
+/**
+ * Returns first text writing attribute or default value.
+ * The default value is empty, which causes no change.
+ * @return first found attribute or default avalue.
+ */
+skb_attribute_writing_t skb_attributes_get_writing(const skb_attribute_t* attributes, int32_t attributes_count);
+
+/**
+ * Returns first font text attribute or default value.
+ * The default value is: font size 16.0, SKB_FONT_FAMILY_DEFAULT, SKB_WEIGHT_NORMAL, SKB_STYLE_NORMAL, SKB_STRETCH_NORMAL.
+ * @return first found attribute or default value.
+ */
+skb_attribute_font_t skb_attributes_get_font(const skb_attribute_t* attributes, int32_t attributes_count);
+
+/**
+ * Returns first spacing attribute or default value.
+ * The default value is: letter spacing 0, word spacing 0.
+ * @return first found attribute or default value.
+ */
+skb_attribute_spacing_t skb_attributes_get_spacing(const skb_attribute_t* attributes, int32_t attributes_count);
+
+/**
+ * Returns first line height attribute or default value.
+ * The default value is: line spacing multiplier 1.0.
+ * @return first found attribute or default value.
+ */
+skb_attribute_line_height_t skb_attributes_get_line_height(const skb_attribute_t* attributes, int32_t attributes_count);
+
+/**
+ * Returns first fill attribute or default value.
+ * The default value is opaque black.
+ * @return first found attribute or default value.
+ */
+skb_attribute_fill_t skb_attributes_get_fill(const skb_attribute_t* attributes, int32_t attributes_count);
+
+
+
 /** Enum describing horizontal alignment of a line of the text. */
 typedef enum {
 	/** Align to the language specific start. Left for LTR and right for RTL. */
@@ -46,44 +208,6 @@ typedef enum {
 	/** Center align the lines. */
 	SKB_ALIGN_CENTER,
 } skb_align_t;
-
-/** Struct describing a single font feature. */
-typedef struct skb_font_feature_t {
-	/** Four letter tag describing the OpenType feature. See SKB_TAG() macro. */
-	uint32_t tag;
-	/** Value of the features, often 1 means on and 0 means off. */
-	uint32_t value;
-} skb_font_feature_t;
-
-/** Text run attributes. */
-typedef struct skb_text_attribs_t {
-	/** Array of font features to assign to the text. */
-	skb_font_feature_t* font_features;
-	/** Number of font features in font_features array. */
-	int32_t font_features_count;
-	/** BCP 47 language tag, e.g. fi-FI. If NULL, do not override language. */
-	const char* lang;
-	/** Font size (px) */
-	float font_size;
-	/** Letter spacing (px) */
-	float letter_spacing;
-	/** Word spacing (px) */
-	float word_spacing;
-	/** Line spacing multiplier. */
-	float line_spacing_multiplier;
-	/** Color of the text. */
-	skb_color_t color;
-	/** Font weight. see skb_weight_t. Zero defaults to SKB_WEIGHT_NORMAL */
-	uint8_t font_weight;
-	/** Font stretch, see skb_stretch_t. Zero defaults to SKB_STRETCH_NORMAL. */
-	uint8_t font_stretch;
-	/** Font family identifier. */
-	uint8_t font_family;
-	/** Font style, see skb_style_t. Zero defaults to SKB_FONT_STYLE_NORMAL. */
-	uint8_t font_style;
-	/** Text direction, see skb_text_dir_t. Zero defaults to SKB_DIR_AUTO. */
-	uint8_t direction;
-} skb_text_attribs_t;
 
 /** Enum describing flags for skb_layout_params_t. */
 enum skb_layout_params_flags_t {
@@ -116,8 +240,9 @@ typedef struct skb_text_attribs_span_t {
 	/** Range of text the attribues apply to. */
 	skb_range_t text_range;
 	/** The text attributes. */
-	skb_text_attribs_t attribs;
-} skb_text_attribs_span_t;
+	skb_attribute_t* attributes;
+	int32_t attributes_count;
+} skb_text_attributes_span_t;
 
 /** Struct describing a run of utf-8 text with attributes. */
 typedef struct skb_text_run_utf8_t {
@@ -126,7 +251,8 @@ typedef struct skb_text_run_utf8_t {
 	/** Length of the text, or -1 if text is null terminated. */
 	int32_t text_count;
 	/** Pointer to the text attributes. */
-	const skb_text_attribs_t* attribs;
+	const skb_attribute_t* attribs;
+	int32_t attribs_count;
 } skb_text_run_utf8_t;
 
 /** Struct describing a run of utf-32 text with attributes. */
@@ -136,7 +262,8 @@ typedef struct skb_text_run_utf32_t {
 	/** Length of the text, or -1 if text is null terminated. */
 	int32_t text_count;
 	/** Pointer to the text attributes. */
-	const skb_text_attribs_t* attribs;
+	const skb_attribute_t* attributes;
+	int32_t attributes_count;
 } skb_text_run_utf32_t;
 
 /** Struct describing shaped and positioned glyph. */
@@ -220,7 +347,7 @@ uint64_t skb_layout_params_hash_append(uint64_t hash, const skb_layout_params_t*
  * @param attribs pointer to the attributes to hash.
  * @return combined hash.
  */
-uint64_t skb_layout_attribs_hash_append(uint64_t hash, const skb_text_attribs_t* attribs);
+uint64_t skb_attributes_hash_append(uint64_t hash, const skb_attribute_t* attribs, int32_t attribs_count);
 
 /**
  * Creates empty layout with specified parameters.
@@ -238,7 +365,10 @@ skb_layout_t* skb_layout_create(const skb_layout_params_t* params);
  * @param attribs attributes to apply for the text.
  * @return newly create layout.
  */
-skb_layout_t* skb_layout_create_utf8(skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const char* text, int32_t text_count, const skb_text_attribs_t* attribs);
+skb_layout_t* skb_layout_create_utf8(
+	skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params,
+	const char* text, int32_t text_count,
+	const skb_attribute_t* attribs, int32_t attribs_count);
 
 /**
  * Creates new layout from the provided parameters, text and text attributes.
@@ -249,7 +379,10 @@ skb_layout_t* skb_layout_create_utf8(skb_temp_alloc_t* temp_alloc, const skb_lay
  * @param attribs attributes to apply for the text.
  * @return newly create layout.
  */
-skb_layout_t* skb_layout_create_utf32(skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const uint32_t* text, int32_t text_count, const skb_text_attribs_t* attribs);
+skb_layout_t* skb_layout_create_utf32(
+	skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params,
+	const uint32_t* text, int32_t text_count,
+	const skb_attribute_t* attribs, int32_t attribs_count);
 
 /**
  * Creates new layout from the provided parameters and text runs.
@@ -260,7 +393,9 @@ skb_layout_t* skb_layout_create_utf32(skb_temp_alloc_t* temp_alloc, const skb_la
  * @param runs_count number of runs.
  * @return newly create layout.
  */
-skb_layout_t* skb_layout_create_from_runs_utf8(skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const skb_text_run_utf8_t* runs, int32_t runs_count);
+skb_layout_t* skb_layout_create_from_runs_utf8(
+	skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params,
+	const skb_text_run_utf8_t* runs, int32_t runs_count);
 
 /**
  * Creates new layout from the provided parameters and text runs.
@@ -271,7 +406,9 @@ skb_layout_t* skb_layout_create_from_runs_utf8(skb_temp_alloc_t* temp_alloc, con
  * @param runs_count number of runs.
  * @return newly create layout.
  */
-skb_layout_t* skb_layout_create_from_runs_utf32(skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const skb_text_run_utf32_t* runs, int32_t runs_count);
+skb_layout_t* skb_layout_create_from_runs_utf32(
+	skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params,
+	const skb_text_run_utf32_t* runs, int32_t runs_count);
 
 /**
  * Sets the layout from the provided parameters, text and text attributes.
@@ -283,7 +420,10 @@ skb_layout_t* skb_layout_create_from_runs_utf32(skb_temp_alloc_t* temp_alloc, co
  * @param attribs attributes to apply for the text.
  * @return newly create layout.
  */
-void skb_layout_set_utf8(skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const char* text, int32_t text_count, const skb_text_attribs_t* attribs);
+void skb_layout_set_utf8(
+	skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params,
+	const char* text, int32_t text_count,
+	const skb_attribute_t* attribs, int32_t attribs_count);
 
 /**
  * Sets the layout from the provided parameters, text and text attributes.
@@ -295,7 +435,10 @@ void skb_layout_set_utf8(skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, con
  * @param attribs attributes to apply for the text.
  * @return newly create layout.
  */
-void skb_layout_set_utf32(skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const uint32_t* text, int32_t text_count, const skb_text_attribs_t* attribs);
+void skb_layout_set_utf32(
+	skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params,
+	const uint32_t* text, int32_t text_count,
+	const skb_attribute_t* attribs, int32_t attribs_count);
 
 /**
  * Sets the layout from the provided parameters and text runs.
@@ -306,7 +449,9 @@ void skb_layout_set_utf32(skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, co
  * @param runs utf-8 text runs to combine into continuous text.
  * @param runs_count number of runs.
  */
-void skb_layout_set_from_runs_utf8(skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const skb_text_run_utf8_t* runs, int32_t runs_count);
+void skb_layout_set_from_runs_utf8(
+	skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params,
+	const skb_text_run_utf8_t* runs, int32_t runs_count);
 
 /**
  * Sets the layout from the provided parameters and text runs.
@@ -317,7 +462,9 @@ void skb_layout_set_from_runs_utf8(skb_layout_t* layout, skb_temp_alloc_t* temp_
  * @param runs utf-32 text runs to combine into continuous text.
  * @param runs_count number of runs.
  */
-void skb_layout_set_from_runs_utf32(skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const skb_text_run_utf32_t* runs, int32_t runs_count);
+void skb_layout_set_from_runs_utf32(
+	skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params,
+	const skb_text_run_utf32_t* runs, int32_t runs_count);
 
 /**
  * Empties the specified layout. Keeps the existing allocations.
@@ -363,7 +510,7 @@ const skb_layout_line_t* skb_layout_get_lines(const skb_layout_t* layout);
 int32_t skb_layout_get_attribute_spans_count(const skb_layout_t* layout);
 
 /** @return const pointer to the attribute spans. See skb_layout_get_attribute_spans_count() to get number of spans. */
-const skb_text_attribs_span_t* skb_layout_get_attribute_spans(const skb_layout_t* layout);
+const skb_text_attributes_span_t* skb_layout_get_attribute_spans(const skb_layout_t* layout);
 
 /** @return typographic bunds of the layout. */
 skb_rect2_t skb_layout_get_bounds(const skb_layout_t* layout);

--- a/include/skb_layout_cache.h
+++ b/include/skb_layout_cache.h
@@ -45,12 +45,13 @@ void skb_layout_cache_destroy(skb_layout_cache_t* cache);
  * @param params layout parameters to use for the layout.
  * @param text text to layout in utf-8 encoding.
  * @param text_count length of the text, or -1 if null terminated.
- * @param attribs text attributes to
+ * @param attributes text attributes to
  * @return const pointer to the requested layout.
  */
 const skb_layout_t* skb_layout_cache_get_utf8(
 	skb_layout_cache_t* cache, skb_temp_alloc_t* temp_alloc,
-	const skb_layout_params_t* params, const char* text, int32_t text_count, const skb_text_attribs_t* attribs);
+	const skb_layout_params_t* params, const char* text, int32_t text_count,
+	const skb_attribute_t* attributes, int32_t attributes_count);
 
 /**
  * Layouts specified text, or returns existing layout from cache if one exists.
@@ -59,12 +60,13 @@ const skb_layout_t* skb_layout_cache_get_utf8(
  * @param params layout parameters to use for the layout.
  * @param text text to layout in utf-32 encoding.
  * @param text_count length of the text, or -1 if null terminated.
- * @param attribs text attributes to use.
+ * @param attributes text attributes to use.
  * @return const pointer to the requested layout.
  */
 const skb_layout_t* skb_layout_cache_get_utf32(
 	skb_layout_cache_t* cache, skb_temp_alloc_t* temp_alloc,
-	const skb_layout_params_t* params, const uint32_t* text, int32_t text_count, const skb_text_attribs_t* attribs);
+	const skb_layout_params_t* params, const uint32_t* text, int32_t text_count,
+	const skb_attribute_t* attributes, int32_t attributes_count);
 
 /**
  * Layouts specified text, or returns existing layout from cache if one exists.

--- a/src/skb_font_collection.c
+++ b/src/skb_font_collection.c
@@ -471,7 +471,7 @@ static bool skb__supports_script(const skb_font_t* font, uint8_t script)
 int32_t skb__match_fonts(
 	const skb_font_collection_t* font_collection,
 	const char* requested_lang, const uint8_t requested_script, uint8_t requested_font_family,
-	skb_style_t requested_style, skb_stretch_t requested_stretch, skb_weight_t requested_weight,
+	skb_weight_t requested_weight, skb_style_t requested_style, skb_stretch_t requested_stretch,
 	skb_font_handle_t* results, int32_t results_cap)
 {
 	// Based on https://drafts.csswg.org/css-fonts-3/#font-style-matching
@@ -692,12 +692,12 @@ int32_t skb__match_fonts(
 int32_t skb_font_collection_match_fonts(
 	skb_font_collection_t* font_collection,
 	const char* requested_lang, const uint8_t requested_script, uint8_t requested_font_family,
-	skb_style_t requested_style, skb_stretch_t requested_stretch, skb_weight_t requested_weight,
+	skb_weight_t requested_weight, skb_style_t requested_style, skb_stretch_t requested_stretch,
 	skb_font_handle_t* results, int32_t results_cap)
 {
 	int32_t results_count =  skb__match_fonts(
 		font_collection, requested_lang, requested_script, requested_font_family,
-		requested_style, requested_stretch, requested_weight, results, results_cap);
+		requested_weight, requested_style, requested_stretch, results, results_cap);
 
 	if (results_count != 0)
 		return results_count;
@@ -707,7 +707,7 @@ int32_t skb_font_collection_match_fonts(
 		if (font_collection->fallback_func(font_collection, requested_lang, requested_script, requested_font_family, font_collection->fallback_context)) {
 			results_count =  skb__match_fonts(
 				font_collection, requested_lang, requested_script, requested_font_family,
-				requested_style, requested_stretch, requested_weight, results, results_cap);
+				requested_weight, requested_style, requested_stretch, results, results_cap);
 		}
 	}
 
@@ -719,7 +719,7 @@ skb_font_handle_t skb_font_collection_get_default_font(skb_font_collection_t* fo
 	skb_font_handle_t results[32];
 	int32_t results_count = skb_font_collection_match_fonts(
 		font_collection, "", SBScriptLATN, font_family,
-		SKB_STYLE_NORMAL, SKB_STRETCH_NORMAL, SKB_WEIGHT_NORMAL,
+		SKB_WEIGHT_NORMAL, SKB_STYLE_NORMAL, SKB_STRETCH_NORMAL,
 		results, SKB_COUNTOF( results ) );
 	return results_count > 0 ? results[0] : (skb_font_handle_t)0;
 }

--- a/src/skb_layout.c
+++ b/src/skb_layout.c
@@ -40,13 +40,13 @@ typedef struct skb_layout_t {
 	int32_t lines_count;
 	int32_t lines_cap;
 
-	skb_text_attribs_span_t* attribute_spans;
+	skb_text_attributes_span_t* attribute_spans;
 	int32_t attribute_spans_count;
 	int32_t attribute_spans_cap;
 
-	skb_font_feature_t* font_features;
-	int32_t font_features_count;
-	int32_t font_features_cap;
+	skb_attribute_t* attributes;
+	int32_t attributes_count;
+	int32_t attributes_cap;
 
 	skb_rect2_t bounds;
 
@@ -67,22 +67,10 @@ uint64_t skb_layout_params_hash_append(uint64_t hash, const skb_layout_params_t*
 	return hash;
 }
 
-uint64_t skb_layout_attribs_hash_append(uint64_t hash, const skb_text_attribs_t* attribs)
+uint64_t skb_attributes_hash_append(uint64_t hash, const skb_attribute_t* attribs, int32_t attribs_count)
 {
-	for (int32_t i = 0; i < attribs->font_features_count; i++) {
-		hash = skb_hash64_append_uint32(hash, attribs->font_features[i].tag);
-		hash = skb_hash64_append_uint32(hash, attribs->font_features[i].value);
-	}
-	hash = skb_hash64_append_str(hash, attribs->lang);
-	hash = skb_hash64_append_float(hash, attribs->font_size);
-	hash = skb_hash64_append_float(hash, attribs->letter_spacing);
-	hash = skb_hash64_append_float(hash, attribs->word_spacing);
-	hash = skb_hash64_append_float(hash, attribs->line_spacing_multiplier);
-	hash = skb_hash64_append(hash, &attribs->color, sizeof(attribs->color));
-	hash = skb_hash64_append_uint8(hash, attribs->font_weight);
-	hash = skb_hash64_append_uint8(hash, attribs->font_style);
-	hash = skb_hash64_append_uint8(hash, attribs->direction);
-
+	for (int32_t i = 0; i < attribs_count; i++)
+		hash = skb_hash64_append(hash, &attribs[i], sizeof(skb_attribute_t));
 	return hash;
 }
 
@@ -96,6 +84,150 @@ uint32_t skb_script_to_iso15924_tag(uint8_t script)
 {
 	return SBScriptGetUnicodeTag(script);
 }
+
+static const char* skb__make_hb_lang(const char* lang)
+{
+	// Use Harfbuzz to sanitize and allocate a string, and return pointer to it.
+	hb_language_t hb_lang = hb_language_from_string(lang, -1);
+	return hb_language_to_string(hb_lang);
+}
+
+skb_attribute_t skb_attribute_make_writing(const char* lang, skb_text_direction_t direction)
+{
+	skb_attribute_t attrib = {
+		.type = SKB_ATTRIBUTE_WRITING,
+		.writing = {
+			.direction = (uint8_t)direction,
+			.lang = skb__make_hb_lang(lang),
+		}
+	};
+	return attrib;
+}
+
+skb_attribute_t skb_attribute_make_font(skb_font_family_t family, float size, skb_weight_t weight, skb_style_t style, skb_stretch_t stretch)
+{
+	return (skb_attribute_t) {
+		.type = SKB_ATTRIBUTE_FONT,
+		.font = {
+			.size = size,
+			.family = (uint8_t)family,
+			.weight = (uint8_t)weight,
+			.style = (uint8_t)style,
+			.stretch = (uint8_t)stretch,
+		}
+	};
+}
+
+skb_attribute_t skb_text_attrib_font_feature_make(uint32_t tag, uint32_t value)
+{
+	return (skb_attribute_t) {
+		.type = SKB_ATTRIBUTE_FONT_FEATURE,
+		.font_feature = {
+			.tag = tag,
+			.value = value,
+		}
+	};
+}
+
+skb_attribute_t skb_attribute_make_font_feature(uint32_t tag, uint32_t value)
+{
+	return (skb_attribute_t) {
+		.type = SKB_ATTRIBUTE_FONT_FEATURE,
+		.font_feature = {
+			.tag = tag,
+			.value = value,
+		},
+	};
+}
+
+skb_attribute_t skb_attribute_make_spacing(float letter, float word)
+{
+	return (skb_attribute_t) {
+		.type = SKB_ATTRIBUTE_SPACING,
+		.spacing = {
+			.letter = letter,
+			.word = word,
+		},
+	};
+}
+
+skb_attribute_t skb_attribute_make_line_height(float line_spacing_multiplier)
+{
+	return (skb_attribute_t) {
+		.type = SKB_ATTRIBUTE_LINE_HEIGHT,
+		.line_height = {
+			.line_spacing_multiplier = line_spacing_multiplier,
+		},
+	};
+}
+
+skb_attribute_t skb_attribute_make_fill(skb_color_t color)
+{
+	return (skb_attribute_t) {
+		.type = SKB_ATTRIBUTE_FILL,
+		.fill = {
+			.color = color,
+		},
+	};
+}
+
+
+skb_attribute_writing_t skb_attributes_get_writing(const skb_attribute_t* attributes, int32_t attributes_count)
+{
+	for (int32_t i = 0; i < attributes_count; i++) {
+		if (attributes[i].type == SKB_ATTRIBUTE_WRITING)
+			return attributes[i].writing;
+	}
+	return (skb_attribute_writing_t) {0};
+}
+
+skb_attribute_font_t skb_attributes_get_font(const skb_attribute_t* attributes, int32_t attributes_count)
+{
+	for (int32_t i = 0; i < attributes_count; i++) {
+		if (attributes[i].type == SKB_ATTRIBUTE_FONT)
+			return attributes[i].font;
+	}
+	return (skb_attribute_font_t) {
+		.size = 16.f,
+		.family = SKB_FONT_FAMILY_DEFAULT,
+		.weight = SKB_WEIGHT_NORMAL,
+		.style = SKB_STYLE_NORMAL,
+		.stretch = SKB_STRETCH_NORMAL,
+	};
+}
+
+skb_attribute_spacing_t skb_attributes_get_spacing(const skb_attribute_t* attributes, int32_t attributes_count)
+{
+	for (int32_t i = 0; i < attributes_count; i++) {
+		if (attributes[i].type == SKB_ATTRIBUTE_SPACING)
+			return attributes[i].spacing;
+	}
+	return (skb_attribute_spacing_t) {0};
+}
+
+skb_attribute_line_height_t skb_attributes_get_line_height(const skb_attribute_t* attributes, int32_t attributes_count)
+{
+	for (int32_t i = 0; i < attributes_count; i++) {
+		if (attributes[i].type == SKB_ATTRIBUTE_LINE_HEIGHT)
+			return attributes[i].line_height;
+	}
+	return (skb_attribute_line_height_t) {
+		.line_spacing_multiplier = 1.f,
+	};
+}
+
+skb_attribute_fill_t skb_attributes_get_fill(const skb_attribute_t* attributes, int32_t attributes_count)
+{
+	for (int32_t i = 0; i < attributes_count; i++) {
+		if (attributes[i].type == SKB_ATTRIBUTE_FILL)
+			return attributes[i].fill;
+	}
+	return (skb_attribute_fill_t) {
+		.color = skb_rgba(0, 0, 0, 255),
+	};
+}
+
+
 
 
 typedef struct skb__script_tag_t {
@@ -199,7 +331,7 @@ static void skb__shape_run(
 	skb__layout_build_context_t* build_context,
 	skb_layout_t* layout,
 	const skb__shaping_run_t* run,
-	const skb_text_attribs_span_t* span,
+	const skb_text_attributes_span_t* span,
 	hb_buffer_t* buffer,
 	const skb_font_handle_t* fonts,
 	int32_t fonts_count,
@@ -207,11 +339,15 @@ static void skb__shape_run(
 {
 	assert(fonts_count > 0);
 
+	const skb_attribute_writing_t attr_writing = skb_attributes_get_writing(span->attributes, span->attributes_count);
+	const skb_attribute_spacing_t attr_spacing = skb_attributes_get_spacing(span->attributes, span->attributes_count);
+	const skb_attribute_font_t attr_font = skb_attributes_get_font(span->attributes, span->attributes_count);
+
 	const skb_font_t* font = skb_font_collection_get_font(layout->params.font_collection, fonts[font_idx]);
 
 	hb_buffer_add_utf32(buffer, layout->text, layout->text_count, run->offset, run->length);
 
-	const hb_language_t lang = span->attribs.lang ? hb_language_from_string(span->attribs.lang, -1) : build_context->lang;
+	const hb_language_t lang = attr_writing.lang ? hb_language_from_string(attr_writing.lang, -1) : build_context->lang;
 
 	hb_buffer_set_direction(buffer, skb_is_rtl(run->direction) ? HB_DIRECTION_RTL : HB_DIRECTION_LTR);
 	hb_buffer_set_script(buffer, skb__sb_script_to_hb(run->script));
@@ -220,7 +356,7 @@ static void skb__shape_run(
 	hb_feature_t features[SKB_MAX_FEATURES];
 	int32_t features_count = 0;
 
-	if (skb_absf(span->attribs.letter_spacing) > 0.01f) {
+	if (skb_absf(attr_spacing.letter) > 0.01f) {
 		// Disable ligratures when letter spacing is requested.
 		skb__add_font_feature(features, &features_count, SKB_TAG_STR("clig"), 0); // Contextual ligatures
 		skb__add_font_feature(features, &features_count, SKB_TAG_STR("dlig"), 0); // Discretionary ligatures
@@ -228,8 +364,10 @@ static void skb__shape_run(
 		skb__add_font_feature(features, &features_count, SKB_TAG_STR("liga"), 0); // Standard ligatures
 		skb__add_font_feature(features, &features_count, SKB_TAG_STR("hlig"), 0); // Historical ligatures
 	}
-	for (int32_t i = 0; i < span->attribs.font_features_count; i++)
-		skb__add_font_feature(features, &features_count, span->attribs.font_features[i].tag, span->attribs.font_features[i].value);
+	for (int32_t i = 0; i < span->attributes_count; i++) {
+		if (span->attributes[i].type == SKB_ATTRIBUTE_FONT_FEATURE)
+			skb__add_font_feature(features, &features_count, span->attributes[i].font_feature.tag, span->attributes[i].font_feature.value);
+	}
 
 	hb_buffer_flags_t flags = HB_BUFFER_FLAG_DEFAULT;
 	if (run->offset == 0)
@@ -249,7 +387,7 @@ static void skb__shape_run(
 	hb_font_get_glyph (font->hb_font, 0x20 /*space*/, 0, &space_gid);
 	hb_position_t space_x_advance = hb_font_get_glyph_h_advance(font->hb_font, space_gid);
 
-	const float scale = span->attribs.font_size * font->upem_scale;
+	const float scale = attr_font.size * font->upem_scale;
 
 	// Reserve space for the glyphs.
 	SKB_ARRAY_RESERVE(layout->glyphs, layout->glyphs_count + glyph_count);
@@ -454,15 +592,15 @@ static void skb__init_text_props(skb_temp_alloc_t* temp_alloc, const char* lang,
 
 static int skb__glyph_cmp_logical(const void *a, const void *b)
 {
-	const skb_glyph_t* ga = (skb_glyph_t*)a;
-	const skb_glyph_t *gb = (skb_glyph_t*)b;
+	const skb_glyph_t* ga = (const skb_glyph_t*)a;
+	const skb_glyph_t *gb = (const skb_glyph_t*)b;
 	return (int)ga->text_range.start - (int)gb->text_range.start;
 }
 
 static int skb__glyph_cmp_visual(const void *a, const void *b)
 {
-	const skb_glyph_t* ga = (skb_glyph_t*)a;
-	const skb_glyph_t *gb = (skb_glyph_t*)b;
+	const skb_glyph_t* ga = (const skb_glyph_t*)a;
+	const skb_glyph_t *gb = (const skb_glyph_t*)b;
 	return ga->visual_idx - gb->visual_idx;
 }
 
@@ -622,6 +760,8 @@ void skb__break_lines(skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, skb_ve
 			skb_font_handle_t prev_font_handle = 0;
 			int32_t prev_span_idx = -1;
 			float baseline_align_offset = 0.f;
+			skb_attribute_font_t attr_font = {0};
+			skb_attribute_line_height_t attr_line_height = {0};
 
 			// Update line dimensions
 			for (int32_t gi = line->glyph_range.start; gi < line->glyph_range.end; gi++) {
@@ -630,17 +770,20 @@ void skb__break_lines(skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, skb_ve
 					prev_font_handle = glyph->font_handle;
 					prev_span_idx = glyph->span_idx;
 
-					const skb_text_attribs_span_t* span = &layout->attribute_spans[glyph->span_idx];
+					const skb_text_attributes_span_t* span = &layout->attribute_spans[glyph->span_idx];
+					attr_font = skb_attributes_get_font(span->attributes, span->attributes_count);
+					attr_line_height = skb_attributes_get_line_height(span->attributes, span->attributes_count);
+
 					const skb_font_t* font = skb_font_collection_get_font(layout->params.font_collection, glyph->font_handle);
 
 					skb_text_property_t text_prop = layout->text_props[glyph->text_range.start];
-					const float baseline = skb_font_get_baseline(layout->params.font_collection, glyph->font_handle, layout->params.baseline, text_prop.direction, text_prop.script, span->attribs.font_size);
+					const float baseline = skb_font_get_baseline(layout->params.font_collection, glyph->font_handle, layout->params.baseline, text_prop.direction, text_prop.script, attr_font.size);
 
 					baseline_align_offset = -baseline;
 
-					line->ascender = skb_minf(line->ascender, font->metrics.ascender * span->attribs.font_size * span->attribs.line_spacing_multiplier - baseline);
-					line->descender = skb_maxf(line->descender, font->metrics.descender * span->attribs.font_size * span->attribs.line_spacing_multiplier - baseline);
-					line_gap = skb_maxf(line_gap, font->metrics.line_gap * span->attribs.font_size * span->attribs.line_spacing_multiplier);
+					line->ascender = skb_minf(line->ascender, font->metrics.ascender * attr_font.size * attr_line_height.line_spacing_multiplier - baseline);
+					line->descender = skb_maxf(line->descender, font->metrics.descender * attr_font.size * attr_line_height.line_spacing_multiplier - baseline);
+					line_gap = skb_maxf(line_gap, font->metrics.line_gap * attr_font.size * attr_line_height.line_spacing_multiplier);
 				}
 
 				glyph->offset_y += baseline_align_offset;
@@ -657,13 +800,16 @@ void skb__break_lines(skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, skb_ve
 			line->last_grapheme_offset = layout->text_count;
 
 			// If we end up here, the last glyph should be a new line.
-			const skb_text_attribs_span_t* last_span = &layout->attribute_spans[layout->attribute_spans_count - 1];
-			const skb_font_handle_t default_font_handle = skb_font_collection_get_default_font(layout->params.font_collection, last_span->attribs.font_family);
+			const skb_text_attributes_span_t* last_span = &layout->attribute_spans[layout->attribute_spans_count - 1];
+			const skb_attribute_font_t attr_font = skb_attributes_get_font(last_span->attributes, last_span->attributes_count);
+			const skb_attribute_line_height_t attr_line_height = skb_attributes_get_line_height(last_span->attributes, last_span->attributes_count);
+
+			const skb_font_handle_t default_font_handle = skb_font_collection_get_default_font(layout->params.font_collection, attr_font.family);
 			const skb_font_t* font = skb_font_collection_get_font(layout->params.font_collection, default_font_handle);
 			if (font) {
-				line->ascender = skb_minf(line->ascender, font->metrics.ascender * last_span->attribs.font_size * last_span->attribs.line_spacing_multiplier);
-				line->descender = skb_maxf(line->descender, font->metrics.descender * last_span->attribs.font_size * last_span->attribs.line_spacing_multiplier);
-				line_gap = skb_maxf(line_gap, font->metrics.line_gap * last_span->attribs.font_size * last_span->attribs.line_spacing_multiplier);
+				line->ascender = skb_minf(line->ascender, font->metrics.ascender * attr_font.size * attr_line_height.line_spacing_multiplier);
+				line->descender = skb_maxf(line->descender, font->metrics.descender * attr_font.size * attr_line_height.line_spacing_multiplier);
+				line_gap = skb_maxf(line_gap, font->metrics.line_gap * attr_font.size * attr_line_height.line_spacing_multiplier);
 			}
 		}
 		line->bounds.height = -line->ascender + line->descender + line_gap;
@@ -743,17 +889,6 @@ void skb__break_lines(skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, skb_ve
 	layout->bounds.height = top_y;
 }
 
-static bool skb__font_features_equals(const skb_font_feature_t* lhs, int32_t lhs_count, const skb_font_feature_t* rhs, int32_t rhs_count)
-{
-	if (lhs_count != rhs_count)
-		return false;
-	for (int32_t i = 0; i < lhs_count; i++) {
-		if (lhs[i].tag != rhs[i].tag || lhs[i].value != rhs[i].value)
-			return false;
-	}
-	return true;
-}
-
 static bool skb__lang_equals(const char* lhs, const char* rhs)
 {
 	if (!lhs && !rhs)
@@ -764,6 +899,7 @@ static bool skb__lang_equals(const char* lhs, const char* rhs)
 	return hb_language_from_string(lhs, -1) == hb_language_from_string(rhs, -1);
 }
 
+/*
 static bool skb__attribs_equals(const skb_text_attribs_t* lhs, const skb_text_attribs_t* rhs)
 {
 	return	lhs->direction == rhs->direction
@@ -777,6 +913,7 @@ static bool skb__attribs_equals(const skb_text_attribs_t* lhs, const skb_text_at
 			&& skb__font_features_equals(lhs->font_features, lhs->font_features_count, rhs->font_features, rhs->font_features_count)
 			&& skb__lang_equals(lhs->lang, rhs->lang);
 }
+*/
 
 typedef struct skb__script_run_iter {
 	const skb_text_property_t* text_props;
@@ -823,11 +960,11 @@ typedef struct skb__text_style_run_iter {
 	bool is_rtl;
 	int32_t span_idx;
 	int32_t span_end;
-	const skb_text_attribs_span_t* spans;
+	const skb_text_attributes_span_t* spans;
 	int32_t spans_count;
 } skb__text_style_run_iter;
 
-static skb__text_style_run_iter skb__text_style_run_iter_make(skb_range_t range, bool is_rtl, const skb_text_attribs_span_t* spans, int32_t spans_count)
+static skb__text_style_run_iter skb__text_style_run_iter_make(skb_range_t range, bool is_rtl, const skb_text_attributes_span_t* spans, int32_t spans_count)
 {
 	skb__text_style_run_iter iter = {
 		.range = range,
@@ -855,7 +992,7 @@ static bool skb__text_style_run_iter_next(skb__text_style_run_iter* iter, skb_ra
 	if (iter->is_rtl) {
 		// Reverse if RTL
 		while (iter->span_idx > iter->span_end) {
-			const skb_text_attribs_span_t* span = &iter->spans[iter->span_idx];
+			const skb_text_attributes_span_t* span = &iter->spans[iter->span_idx];
 			if (span->text_range.end <= iter->range.start) {
 				iter->span_idx = iter->span_end;
 				return false;
@@ -874,7 +1011,7 @@ static bool skb__text_style_run_iter_next(skb__text_style_run_iter* iter, skb_ra
 	} else {
 		// Forward if RTL
 		while (iter->span_idx < iter->span_end) {
-			const skb_text_attribs_span_t* span = &iter->spans[iter->span_idx];
+			const skb_text_attributes_span_t* span = &iter->spans[iter->span_idx];
 			if (span->text_range.start > iter->range.end) {
 				iter->span_idx = iter->span_end;
 				return false;
@@ -971,8 +1108,10 @@ static void skb__itemize(skb__layout_build_context_t* build_context, skb_layout_
 			skb_range_t style_range = {0};
 			int32_t style_span_idx = 0;
 			while (skb__text_style_run_iter_next(&style_iter, &style_range, &style_span_idx)) {
-				const skb_text_attribs_span_t* span = &layout->attribute_spans[style_span_idx];
-				const uint8_t style_direction = span->attribs.direction != SKB_DIRECTION_AUTO ? span->attribs.direction : bidi_direction;
+				const skb_text_attributes_span_t* span = &layout->attribute_spans[style_span_idx];
+
+				const skb_attribute_writing_t attr_writing = skb_attributes_get_writing(span->attributes, span->attributes_count);
+				const uint8_t style_direction = attr_writing.direction != SKB_DIRECTION_AUTO ? attr_writing.direction : bidi_direction;
 
 				// Process the rest of the itemization forward, and reverse the sequence of runs once completed.
 				int32_t first_run = build_context->shaping_runs_count;
@@ -1103,8 +1242,10 @@ static void skb__apply_lang_based_word_breaks(const skb__layout_build_context_t*
 
 	for (int32_t i = 0; i < build_context->shaping_runs_count; ++i) {
 		const skb__shaping_run_t* run = &build_context->shaping_runs[i];
-		const skb_text_attribs_span_t* span = &layout->attribute_spans[run->shaping_span_idx];
-		const hb_language_t run_lang = span->attribs.lang ? hb_language_from_string(span->attribs.lang, -1) : build_context->lang;
+		const skb_text_attributes_span_t* span = &layout->attribute_spans[run->shaping_span_idx];
+
+		const skb_attribute_writing_t attr_writing = skb_attributes_get_writing(span->attributes, span->attributes_count);
+		const hb_language_t run_lang = attr_writing.lang ? hb_language_from_string(attr_writing.lang, -1) : build_context->lang;
 
 		if (skb__is_japanese_script(run->script) && hb_language_matches(lang_ja, run_lang)) {
 			// Merge supported runs into one longer one.
@@ -1184,14 +1325,18 @@ static void skb__build_layout(skb_layout_t* layout, skb_temp_alloc_t* temp_alloc
 	hb_buffer_t* buffer = hb_buffer_create();
 	for (int32_t i = 0; i < build_context.shaping_runs_count; ++i) {
 		const skb__shaping_run_t* run = &build_context.shaping_runs[i];
-		const skb_text_attribs_span_t* span = &layout->attribute_spans[run->shaping_span_idx];
-		const uint8_t font_family = run->is_emoji ? SKB_FONT_FAMILY_EMOJI : span->attribs.font_family;
-		const hb_language_t run_lang = span->attribs.lang ? hb_language_from_string(span->attribs.lang, -1) : build_context.lang;
+		const skb_text_attributes_span_t* span = &layout->attribute_spans[run->shaping_span_idx];
+
+		const skb_attribute_font_t attr_font = skb_attributes_get_font(span->attributes, span->attributes_count);
+		const skb_attribute_writing_t attr_writing = skb_attributes_get_writing(span->attributes, span->attributes_count);
+
+		const uint8_t font_family = run->is_emoji ? SKB_FONT_FAMILY_EMOJI : attr_font.family;
+		const hb_language_t run_lang = attr_writing.lang ? hb_language_from_string(attr_writing.lang, -1) : build_context.lang;
 
 		skb_font_handle_t fonts[32];
 		int32_t fonts_count = skb_font_collection_match_fonts(
 			layout->params.font_collection, hb_language_to_string(run_lang), run->script, font_family,
-			span->attribs.font_style, span->attribs.font_stretch, span->attribs.font_weight,
+			attr_font.weight, attr_font.style, attr_font.stretch,
 			fonts, SKB_COUNTOF(fonts));
 
 		if (fonts_count == 0) {
@@ -1219,18 +1364,19 @@ static void skb__build_layout(skb_layout_t* layout, skb_temp_alloc_t* temp_alloc
 
 		// Apply spacing at the end of a glyph cluster.
 		if (next_gi >= layout->glyphs_count || layout->glyphs[next_gi].text_range.start != glyph->text_range.start) {
-			skb_text_attribs_span_t* span = &layout->attribute_spans[glyph->span_idx];
+			const skb_text_attributes_span_t* span = &layout->attribute_spans[glyph->span_idx];
+			const skb_attribute_spacing_t attr_spacing = skb_attributes_get_spacing(span->attributes, span->attributes_count);
 
 			// Apply letter spacing for each grapheme.
 			skb_text_property_t text_props = layout->text_props[glyph->text_range.end-1];
 			if (text_props.flags & SKB_TEXT_PROP_GRAPHEME_BREAK) {
 				if ((text_props.flags & SKB_TEXT_PROP_WHITESPACE) || skb__allow_letter_spacing(text_props.script))
-					glyph->advance_x += span->attribs.letter_spacing;
+					glyph->advance_x += attr_spacing.letter;
 			}
 
 			// Apply word spacing for each white space.
 			if (layout->text_props[glyph->text_range.end-1].flags & SKB_TEXT_PROP_WHITESPACE)
-				glyph->advance_x += span->attribs.word_spacing;
+				glyph->advance_x += attr_spacing.word;
 		}
 	}
 
@@ -1238,47 +1384,34 @@ static void skb__build_layout(skb_layout_t* layout, skb_temp_alloc_t* temp_alloc
 	skb__break_lines(layout, temp_alloc, layout->params.origin, layout->params.line_break_width, layout->params.flags & SKB_LAYOUT_PARAMS_IGNORE_MUST_LINE_BREAKS);
 }
 
-
-static void skb__append_attribs(skb_layout_t* layout, const skb_text_attribs_t* attribs, const char* lang, int32_t text_start, int32_t text_end)
+static int skb__attribute_cmp(const void* a, const void* b)
 {
+	const skb_attribute_t* attr_a = a;
+	const skb_attribute_t* attr_b = b;
+	return (int32_t)attr_a->type - (int32_t)attr_b->type;
+}
+
+static void skb__append_attributes(skb_layout_t* layout, const skb_attribute_t* attributes, int32_t attribs_count, int32_t text_start, int32_t text_end)
+{
+	// TODO: fix!
 	// If the style is the same as previous span, combine.
-	if (layout->attribute_spans_count > 0 && skb__attribs_equals(&layout->attribute_spans[layout->attribute_spans_count - 1].attribs, attribs)) {
+/*	if (layout->attribute_spans_count > 0 && skb__attribs_equals(&layout->attribute_spans[layout->attribute_spans_count - 1].attribs, attribs)) {
 		layout->attribute_spans[layout->attribute_spans_count - 1].text_range.end = layout->text_count;
-	} else {
+	} else*/ {
 		SKB_ARRAY_RESERVE(layout->attribute_spans, layout->attribute_spans_count + 1);
-		skb_text_attribs_span_t* span = &layout->attribute_spans[layout->attribute_spans_count++];
+		skb_text_attributes_span_t* span = &layout->attribute_spans[layout->attribute_spans_count++];
 		span->text_range.start = text_start;
 		span->text_range.end = text_end;
-		span->attribs = *attribs;
 
-		if (span->attribs.lang) {
-			// We're sneakily taking advantage of harfbuzz, which allocates canonized strings for the languages, so we just stash the pointer.
-			hb_language_t hb_lang = hb_language_from_string(lang, -1);
-			span->attribs.lang = hb_language_to_string(hb_lang);
-		}
+		SKB_ARRAY_RESERVE(layout->attributes, layout->attributes_count + attribs_count);
+        span->attributes = &layout->attributes[layout->attributes_count];
+        span->attributes_count = attribs_count;
 
-		if (attribs->font_features && attribs->font_features_count > 0) {
-			// Copy features
-			skb_font_feature_t* old_features = layout->font_features;
-			SKB_ARRAY_RESERVE(layout->font_features, layout->font_features_count + attribs->font_features_count);
-			memcpy(layout->font_features, attribs->font_features, attribs->font_features_count * sizeof(skb_font_feature_t));
-			layout->font_features_count += attribs->font_features_count;
+        memcpy(span->attributes, attributes, attribs_count * sizeof(skb_attribute_t));
 
-			// Update all pointers, the array reserve above may have relocated the array.
-			if (old_features != layout->font_features) {
-				skb_font_feature_t* features = layout->font_features;
-				for (int32_t si = 0; si < layout->attribute_spans_count; si++) {
-					skb_text_attribs_span_t* s = &layout->attribute_spans[si];
-					if (s->attribs.font_features_count > 0) {
-						s->attribs.font_features = features;
-						features += s->attribs.font_features_count;
-					}
-				}
-			}
-		} else {
-			span->attribs.font_features = NULL;
-			span->attribs.font_features_count = 0;
-		}
+        qsort(span->attributes, span->attributes_count, sizeof(skb_attribute_t), skb__attribute_cmp);
+
+        layout->attributes_count += attribs_count;
 	}
 }
 
@@ -1303,22 +1436,24 @@ skb_layout_t* skb_layout_create(const skb_layout_params_t* params)
 	return layout;
 }
 
-skb_layout_t* skb_layout_create_utf8(skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const char* text, int32_t text_count, const skb_text_attribs_t* attribs)
+skb_layout_t* skb_layout_create_utf8(skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const char* text, int32_t text_count, const skb_attribute_t* attribs, int32_t attribs_count)
 {
 	skb_text_run_utf8_t run = {
 		.text = text,
 		.text_count = text_count,
 		.attribs = attribs,
+		.attribs_count = attribs_count,
 	};
 	return skb_layout_create_from_runs_utf8(temp_alloc, params, &run, 1);
 }
 
-skb_layout_t* skb_layout_create_utf32(skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const uint32_t* text, int32_t text_count, const skb_text_attribs_t* attribs)
+skb_layout_t* skb_layout_create_utf32(skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const uint32_t* text, int32_t text_count, const skb_attribute_t* attribs, int32_t attribs_count)
 {
 	skb_text_run_utf32_t run = {
 		.text = text,
 		.text_count = text_count,
-		.attribs = attribs,
+		.attributes = attribs,
+		.attributes_count = attribs_count
 	};
 	return skb_layout_create_from_runs_utf32(temp_alloc, params, &run, 1);
 }
@@ -1337,22 +1472,24 @@ skb_layout_t* skb_layout_create_from_runs_utf32(skb_temp_alloc_t* temp_alloc, co
 	return layout;
 }
 
-void skb_layout_set_utf8(skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const char* text, int32_t text_count, const skb_text_attribs_t* attribs)
+void skb_layout_set_utf8(skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const char* text, int32_t text_count, const skb_attribute_t* attribs, int32_t attribs_count)
 {
 	skb_text_run_utf8_t run = {
 		.text = text,
 		.text_count = text_count,
 		.attribs = attribs,
+		.attribs_count = attribs_count,
 	};
 	skb_layout_set_from_runs_utf8(layout, temp_alloc, params, &run, 1);
 }
 
-void skb_layout_set_utf32(skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const uint32_t* text, int32_t text_count, const skb_text_attribs_t* attribs)
+void skb_layout_set_utf32(skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const uint32_t* text, int32_t text_count, const skb_attribute_t* attribs, int32_t attribs_count)
 {
 	skb_text_run_utf32_t run = {
 		.text = text,
 		.text_count = text_count,
-		.attribs = attribs,
+		.attributes = attribs,
+		.attributes_count = attribs_count,
 	};
 	skb_layout_set_from_runs_utf32(layout, temp_alloc, params, &run, 1);
 }
@@ -1366,11 +1503,20 @@ void skb_layout_reset(skb_layout_t* layout)
 	layout->glyphs_count = 0;
 	layout->lines_count = 0;
 	layout->attribute_spans_count = 0;
-	layout->font_features_count = 0;
+	layout->attributes_count = 0;
 	layout->bounds = skb_rect2_make_undefined();
 	layout->resolved_direction = SKB_DIRECTION_AUTO;
 }
 
+static const char* skb__resolve_lang(const skb_layout_t* layout, const skb_text_attributes_span_t* span)
+{
+	const char* lang = NULL;
+	for (int32_t i = 0; i < span->attributes_count; i++) {
+		if (span->attributes[i].type == SKB_ATTRIBUTE_WRITING)
+			lang = span->attributes[i].writing.lang;
+	}
+	return lang ? lang : layout->params.lang;
+}
 
 static void skb__init_text_props_from_spans(skb_layout_t* layout, skb_temp_alloc_t* temp_alloc)
 {
@@ -1380,8 +1526,9 @@ static void skb__init_text_props_from_spans(skb_layout_t* layout, skb_temp_alloc
 	int32_t cur_offset = 0;
 	const char* prev_lang = layout->params.lang;
 	for (int32_t i = 0; i < layout->attribute_spans_count; i++) {
-		const skb_text_attribs_span_t* span = &layout->attribute_spans[i];
-		const char* lang = span->attribs.lang ? span->attribs.lang : layout->params.lang;
+		const skb_text_attributes_span_t* span = &layout->attribute_spans[i];
+		const char* lang = skb__resolve_lang(layout, span);
+
 		if (lang != prev_lang) {
 			if (cur_offset > start_offset)
 				skb__init_text_props(temp_alloc, prev_lang, layout->text + start_offset, layout->text_props + start_offset, cur_offset - start_offset);
@@ -1405,26 +1552,22 @@ void skb_layout_set_from_runs_utf8(skb_layout_t* layout, skb_temp_alloc_t* temp_
 
 	// Reserve memory for the text and attributes
 	int32_t total_text_count = 0;
-	int32_t total_features_count = 0;
+	int32_t total_attribs_count = 0;
 	for (int32_t i = 0; i < runs_count; i++) {
 		text_counts[i] = runs[i].text_count >= 0 ? runs[i].text_count : (int32_t)strlen(runs[i].text);
 		total_text_count += text_counts[i];
-		total_features_count += runs[i].attribs ? runs[i].attribs->font_features_count : 0;
+		total_attribs_count += runs[i].attribs_count;
 	}
 	skb__reserve_text(layout, total_text_count);
 
 	// Reserve space for spans and font features.
 	SKB_ARRAY_RESERVE(layout->attribute_spans, runs_count);
-	SKB_ARRAY_RESERVE(layout->font_features, total_features_count);
+	SKB_ARRAY_RESERVE(layout->attributes, total_attribs_count);
 
 	for (int32_t i = 0; i < runs_count; i++) {
-		const skb_text_attribs_t* attribs = runs[i].attribs;
-		assert(attribs);
-		const char* lang = attribs->lang ? attribs->lang : layout->params.lang;
-
 		int32_t offset = layout->text_count;
 		int32_t count = skb__append_text_utf8(layout, runs[i].text, text_counts[i]);
-		skb__append_attribs(layout, attribs, lang, offset, offset + count);
+		skb__append_attributes(layout, runs[i].attribs, runs[i].attribs_count, offset, offset + count);
 	}
 
 	skb__init_text_props_from_spans(layout, temp_alloc);
@@ -1445,26 +1588,22 @@ void skb_layout_set_from_runs_utf32(skb_layout_t* layout, skb_temp_alloc_t* temp
 
 	// Reserve memory for the text
 	int32_t total_text_count = 0;
-	int32_t total_features_count = 0;
+	int32_t total_attribs_count = 0;
 	for (int32_t i = 0; i < runs_count; i++) {
 		text_counts[i] = runs[i].text_count >= 0 ? runs[i].text_count : skb_utf32_strlen(runs[i].text);
 		total_text_count += text_counts[i];
-		total_features_count += runs[i].attribs ? runs[i].attribs->font_features_count : 0;
+		total_attribs_count += runs[i].attributes_count;
 	}
 	skb__reserve_text(layout, total_text_count);
 
 	// Reserve space for spans and font features.
 	SKB_ARRAY_RESERVE(layout->attribute_spans, runs_count);
-	SKB_ARRAY_RESERVE(layout->font_features, total_features_count);
+	SKB_ARRAY_RESERVE(layout->attributes, total_attribs_count);
 
 	for (int32_t i = 0; i < runs_count; i++) {
-		const skb_text_attribs_t* attribs = runs[i].attribs;
-		assert(attribs);
-		const char* lang = attribs->lang ? attribs->lang : layout->params.lang;
-
 		int32_t offset = layout->text_count;
 		int32_t count = skb__append_text_utf32(layout, runs[i].text, text_counts[i]);
-		skb__append_attribs(layout, attribs, lang, offset, offset + count);
+		skb__append_attributes(layout, runs[i].attributes, runs[i].attributes_count, offset, offset + count);
 	}
 
 	skb__init_text_props_from_spans(layout, temp_alloc);
@@ -1478,7 +1617,7 @@ void skb_layout_destroy(skb_layout_t* layout)
 {
 	if (!layout) return;
 
-	skb_free(layout->font_features);
+	skb_free(layout->attributes);
 	skb_free(layout->attribute_spans);
 	skb_free(layout->glyphs);
 	skb_free(layout->text);
@@ -1534,7 +1673,7 @@ int32_t skb_layout_get_lines_count(const skb_layout_t* layout)
 	return layout->lines_count;
 }
 
-const skb_text_attribs_span_t* skb_layout_get_attribute_spans(const skb_layout_t* layout)
+const skb_text_attributes_span_t* skb_layout_get_attribute_spans(const skb_layout_t* layout)
 {
 	assert(layout);
 	return layout->attribute_spans;
@@ -1806,7 +1945,7 @@ skb_visual_caret_t skb_layout_get_visual_caret_at_line(const skb_layout_t* layou
 	skb_caret_iterator_t caret_iter = skb_caret_iterator_make(layout, line_idx);
 
 	skb_font_handle_t font_handle = 0;
-	skb_text_attribs_span_t* attribute_span = NULL;
+	skb_text_attributes_span_t* attribute_span = NULL;
 	float x = 0.f;
 	float advance = 0.f;
 	skb_caret_iterator_result_t left = {0};
@@ -1834,12 +1973,13 @@ skb_visual_caret_t skb_layout_get_visual_caret_at_line(const skb_layout_t* layou
 	}
 
 	if (font_handle && attribute_span) {
-		skb_font_metrics_t font_metrics = skb_font_get_metrics(layout->params.font_collection, font_handle);
-		skb_caret_metrics_t caret_metrics = skb_font_get_caret_metrics(layout->params.font_collection, font_handle);
-		const float font_size = attribute_span->attribs.font_size;
-		vis_caret.x -= caret_metrics.slope * font_metrics.descender * font_size;
-		vis_caret.y += font_metrics.ascender * font_size;
-		vis_caret.height = (-font_metrics.ascender + font_metrics.descender) * font_size;
+		const skb_font_metrics_t font_metrics = skb_font_get_metrics(layout->params.font_collection, font_handle);
+		const skb_caret_metrics_t caret_metrics = skb_font_get_caret_metrics(layout->params.font_collection, font_handle);
+		const skb_attribute_font_t attr_font = skb_attributes_get_font(attribute_span->attributes, attribute_span->attributes_count);
+
+		vis_caret.x -= caret_metrics.slope * font_metrics.descender * attr_font.size;
+		vis_caret.y += font_metrics.ascender * attr_font.size;
+		vis_caret.height = (-font_metrics.ascender + font_metrics.descender) * attr_font.size;
 		vis_caret.width = vis_caret.height * caret_metrics.slope;
 
 	}

--- a/src/skb_layout_cache.c
+++ b/src/skb_layout_cache.c
@@ -94,7 +94,9 @@ skb__cached_layout_t* skb__layout_cache_get_or_insert(skb_layout_cache_t* cache,
 	return cached_layout;
 }
 
-const skb_layout_t* skb_layout_cache_get_utf8(skb_layout_cache_t* cache, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const char* text, int32_t text_count, const skb_text_attribs_t* attribs)
+const skb_layout_t* skb_layout_cache_get_utf8(
+	skb_layout_cache_t* cache, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params,
+	const char* text, int32_t text_count, const skb_attribute_t* attributes, int32_t attributes_count)
 {
 	assert(cache);
 
@@ -104,11 +106,11 @@ const skb_layout_t* skb_layout_cache_get_utf8(skb_layout_cache_t* cache, skb_tem
 	uint64_t hash = skb_hash64_empty();
 	hash = skb_hash64_append(hash, text, text_count);
 	hash = skb_layout_params_hash_append(hash, params);
-	hash = skb_layout_attribs_hash_append(hash, attribs);
+	hash = skb_attributes_hash_append(hash, attributes, attributes_count);
 
 	skb__cached_layout_t* cached_layout = skb__layout_cache_get_or_insert(cache, hash);
 	if (!cached_layout->layout) {
-		cached_layout->layout = skb_layout_create_utf8(temp_alloc, params, text, text_count, attribs);
+		cached_layout->layout = skb_layout_create_utf8(temp_alloc, params, text, text_count, attributes, attributes_count);
 	}
 	assert(cached_layout);
 	assert(cached_layout->layout);
@@ -116,7 +118,9 @@ const skb_layout_t* skb_layout_cache_get_utf8(skb_layout_cache_t* cache, skb_tem
 	return cached_layout->layout;
 }
 
-const skb_layout_t* skb_layout_cache_get_utf32(skb_layout_cache_t* cache, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const uint32_t* text, int32_t text_count, const skb_text_attribs_t* attribs)
+const skb_layout_t* skb_layout_cache_get_utf32(
+	skb_layout_cache_t* cache, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params,
+	const uint32_t* text, int32_t text_count, const skb_attribute_t* attributes, int32_t attributes_count)
 {
 	assert(cache);
 
@@ -126,11 +130,11 @@ const skb_layout_t* skb_layout_cache_get_utf32(skb_layout_cache_t* cache, skb_te
 	uint64_t hash = skb_hash64_empty();
 	hash = skb_hash64_append(hash, text, text_count * sizeof(uint32_t));
 	hash = skb_layout_params_hash_append(hash, params);
-	hash = skb_layout_attribs_hash_append(hash, attribs);
+	hash = skb_attributes_hash_append(hash, attributes, attributes_count);
 
 	skb__cached_layout_t* cached_layout = skb__layout_cache_get_or_insert(cache, hash);
 	if (!cached_layout->layout) {
-		cached_layout->layout = skb_layout_create_utf32(temp_alloc, params, text, text_count, attribs);
+		cached_layout->layout = skb_layout_create_utf32(temp_alloc, params, text, text_count, attributes, attributes_count);
 	}
 	assert(cached_layout);
 	assert(cached_layout->layout);
@@ -138,7 +142,9 @@ const skb_layout_t* skb_layout_cache_get_utf32(skb_layout_cache_t* cache, skb_te
 	return cached_layout->layout;
 }
 
-const skb_layout_t* skb_layout_cache_get_from_runs_utf8(skb_layout_cache_t* cache, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const skb_text_run_utf8_t* runs, int32_t runs_count)
+const skb_layout_t* skb_layout_cache_get_from_runs_utf8(
+	skb_layout_cache_t* cache, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params,
+	const skb_text_run_utf8_t* runs, int32_t runs_count)
 {
 	assert(cache);
 
@@ -152,7 +158,7 @@ const skb_layout_t* skb_layout_cache_get_from_runs_utf8(skb_layout_cache_t* cach
 
 		hash = skb_hash64_append(hash, fixed_runs[i].text, fixed_runs[i].text_count);
 		hash = skb_layout_params_hash_append(hash, params);
-		hash = skb_layout_attribs_hash_append(hash, fixed_runs[i].attribs);
+		hash = skb_attributes_hash_append(hash, fixed_runs[i].attribs, fixed_runs[i].attribs_count);
 	}
 
 	skb__cached_layout_t* cached_layout = skb__layout_cache_get_or_insert(cache, hash);
@@ -167,7 +173,9 @@ const skb_layout_t* skb_layout_cache_get_from_runs_utf8(skb_layout_cache_t* cach
 	return cached_layout->layout;
 }
 
-const skb_layout_t* skb_layout_cache_get_from_runs_utf32(skb_layout_cache_t* cache, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const skb_text_run_utf32_t* runs, int32_t runs_count)
+const skb_layout_t* skb_layout_cache_get_from_runs_utf32(
+	skb_layout_cache_t* cache, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params,
+	const skb_text_run_utf32_t* runs, int32_t runs_count)
 {
 	assert(cache);
 
@@ -181,7 +189,7 @@ const skb_layout_t* skb_layout_cache_get_from_runs_utf32(skb_layout_cache_t* cac
 
 		hash = skb_hash64_append(hash, fixed_runs[i].text, fixed_runs[i].text_count);
 		hash = skb_layout_params_hash_append(hash, params);
-		hash = skb_layout_attribs_hash_append(hash, fixed_runs[i].attribs);
+		hash = skb_attributes_hash_append(hash, fixed_runs[i].attributes, fixed_runs[i].attributes_count);
 	}
 
 	skb__cached_layout_t* cached_layout = skb__layout_cache_get_or_insert(cache, hash);

--- a/test/test_editor.c
+++ b/test/test_editor.c
@@ -6,14 +6,16 @@
 
 static int test_init(void)
 {
+	skb_attribute_t attributes[] = {
+		skb_attribute_make_font(SKB_FONT_FAMILY_DEFAULT, 15.f, SKB_WEIGHT_NORMAL, SKB_STYLE_NORMAL, SKB_STRETCH_NORMAL),
+	};
+
 	skb_editor_params_t params = {
 		 .layout_params = {
 		 	.font_collection = NULL,
 		 },
-		. text_attribs = {
-		 	.font_size = 15.f,
-		 	.font_weight = SKB_WEIGHT_NORMAL
-		},
+		.text_attributes = attributes,
+		.text_attributes_count = SKB_COUNTOF(attributes),
 		.base_direction = SKB_DIRECTION_LTR,
 		.caret_mode = SKB_CARET_MODE_SKRIBIDI,
 	};

--- a/test/test_layout.c
+++ b/test/test_layout.c
@@ -31,12 +31,12 @@ static int test_missing_script(void)
 	skb_layout_params_t layout_params = {
 		.font_collection = font_collection,
 	};
-	skb_text_attribs_t attribs = {
-		.font_family = SKB_FONT_FAMILY_DEFAULT,
+	skb_attribute_t attributes[] = {
+		skb_attribute_make_font(SKB_FONT_FAMILY_DEFAULT, 15.f, SKB_WEIGHT_NORMAL, SKB_STYLE_NORMAL, SKB_STRETCH_NORMAL),
 	};
 
 	// The loaded font should not support the script of the text. We should still get a valid layout, but with invalid glyphs.
-	skb_layout_t* layout = skb_layout_create_utf8(temp_alloc, &layout_params, "今天天气晴朗", -1, &attribs);
+	skb_layout_t* layout = skb_layout_create_utf8(temp_alloc, &layout_params, "今天天气晴朗", -1, attributes, SKB_COUNTOF(attributes));
 	ENSURE(layout != NULL);
 	ENSURE(skb_layout_get_glyphs_count(layout) > 0);
 	const skb_glyph_t* glyphs = skb_layout_get_glyphs(layout);


### PR DESCRIPTION
Removed skb_text_attribs_t in favor of array of attributes skb_attribute_t. This is done in order to make the attribute system user extensible, and to support many multiple attributes of same type (e.g. decorations, shadows) later.

- removed skb_text_attribs_t
- added text attributes for writing, font, font features, spacing, line height and fill color
- added tagged union skb_attribute_t which can hold any of the above attributes
- changed the API to take array of skb_attribute_t instead of skb_text_attribs_t