### PR TITLE
Add MacOS-style caret jumping on command+left/right, command+up/down, and option+left/right

### DIFF
--- a/include/skb_editor.h
+++ b/include/skb_editor.h
@@ -49,13 +49,13 @@ typedef enum {
 	SKB_CARET_MODE_SIMPLE,
 } skb_editor_caret_mode_t;
 
-/** Enum describing the jump mode for word navigation. */
+/** Enum describing the behavior mode for editor operations. */
 typedef enum {
-	/** Default mode, standard word jumping behavior. */
-	SKB_JUMP_MODE_DEFAULT = 0,
+	/** Default mode, standard behavior. */
+	SKB_BEHAVIOR_DEFAULT = 0,
 	/** MacOS mode, option+arrow and command+arrow follow MacOS text editing conventions. */
-	SKB_JUMP_MODE_MACOS,
-} skb_editor_jump_mode_t;
+	SKB_BEHAVIOR_MACOS,
+} skb_editor_behavior_t;
 
 /** Struct describing parameters for the text editor. */
 typedef struct skb_editor_params_t {
@@ -73,8 +73,9 @@ typedef struct skb_editor_params_t {
 	uint8_t base_direction;
 	/** Care movement mode */
 	skb_editor_caret_mode_t caret_mode;
-	/** Jump mode for word navigation (default vs macOS style) */
-	skb_editor_jump_mode_t jump_mode;
+	/** Behavior mode for editor operations (default vs macOS style). This includes how keyboard
+	 * navigation works in the text editor. */
+	skb_editor_behavior_t editor_behavior;
 	/** Maximum number of undo levels, if zero, set to default undo levels, if < 0 undo is disabled. */
 	int32_t max_undo_levels;
 } skb_editor_params_t;

--- a/include/skb_editor.h
+++ b/include/skb_editor.h
@@ -49,6 +49,14 @@ typedef enum {
 	SKB_CARET_MODE_SIMPLE,
 } skb_editor_caret_mode_t;
 
+/** Enum describing the jump mode for word navigation. */
+typedef enum {
+	/** Default mode, standard word jumping behavior. */
+	SKB_JUMP_MODE_DEFAULT = 0,
+	/** MacOS mode, option+arrow and command+arrow follow MacOS text editing conventions. */
+	SKB_JUMP_MODE_MACOS,
+} skb_editor_jump_mode_t;
+
 /** Struct describing parameters for the text editor. */
 typedef struct skb_editor_params_t {
 	/** Layout parameters used for each paragraph layout. */
@@ -65,6 +73,8 @@ typedef struct skb_editor_params_t {
 	uint8_t base_direction;
 	/** Care movement mode */
 	skb_editor_caret_mode_t caret_mode;
+	/** Jump mode for word navigation (default vs macOS style) */
+	skb_editor_jump_mode_t jump_mode;
 	/** Maximum number of undo levels, if zero, set to default undo levels, if < 0 undo is disabled. */
 	int32_t max_undo_levels;
 } skb_editor_params_t;
@@ -97,6 +107,8 @@ typedef enum {
 	SKB_MOD_NONE = 0,
 	SKB_MOD_SHIFT = 0x01,
 	SKB_MOD_CONTROL = 0x02,
+	SKB_MOD_OPTION = 0x04,
+	SKB_MOD_COMMAND = 0x08,
 } skb_editor_key_mod_t;
 
 /**

--- a/include/skb_layout.h
+++ b/include/skb_layout.h
@@ -394,7 +394,9 @@ enum skb_text_prop_flags_t {
 	/** The codepoint is a control character. */
 	SKB_TEXT_PROP_CONTROL          = 1 << 5,
 	/** The codepoint is a white space character. */
-	SKB_TEXT_PROP_WHITESPACE       = 1 << 6
+	SKB_TEXT_PROP_WHITESPACE       = 1 << 6,
+	/** The codepoint is a punctuation character. */
+	SKB_TEXT_PROP_PUNCTUATION      = 1 << 7,
 };
 
 /** Struct describing properties if a single codepoint. */

--- a/src/skb_layout.c
+++ b/src/skb_layout.c
@@ -594,12 +594,22 @@ static void skb__init_text_props(skb_temp_alloc_t* temp_alloc, const char* lang,
 	for (int i = 0; i < text_count; i++) {
 		const hb_unicode_general_category_t category = hb_unicode_general_category(unicode_funcs, text[i]);
 		SKB_SET_FLAG(text_attribs[i].flags, SKB_TEXT_PROP_CONTROL, category == HB_UNICODE_GENERAL_CATEGORY_CONTROL);
-		const bool is_whitespace = (
+
+		const bool is_whitespace =
 			category == HB_UNICODE_GENERAL_CATEGORY_LINE_SEPARATOR
 			|| category == HB_UNICODE_GENERAL_CATEGORY_PARAGRAPH_SEPARATOR
-			|| category == HB_UNICODE_GENERAL_CATEGORY_SPACE_SEPARATOR
-		);
+			|| category == HB_UNICODE_GENERAL_CATEGORY_SPACE_SEPARATOR;
 		SKB_SET_FLAG(text_attribs[i].flags, SKB_TEXT_PROP_WHITESPACE, is_whitespace);
+
+		const bool is_punctuation =
+			category == HB_UNICODE_GENERAL_CATEGORY_CONNECT_PUNCTUATION
+			|| category == HB_UNICODE_GENERAL_CATEGORY_DASH_PUNCTUATION
+			|| category == HB_UNICODE_GENERAL_CATEGORY_CLOSE_PUNCTUATION
+			|| category == HB_UNICODE_GENERAL_CATEGORY_FINAL_PUNCTUATION
+			|| category == HB_UNICODE_GENERAL_CATEGORY_INITIAL_PUNCTUATION
+			|| category == HB_UNICODE_GENERAL_CATEGORY_OTHER_PUNCTUATION
+			|| category == HB_UNICODE_GENERAL_CATEGORY_OPEN_PUNCTUATION;
+		SKB_SET_FLAG(text_attribs[i].flags, SKB_TEXT_PROP_PUNCTUATION, is_punctuation);
 	}
 
 	SKB_TEMP_FREE(temp_alloc, breaks);

--- a/test/test_editor.c
+++ b/test/test_editor.c
@@ -1,8 +1,10 @@
 // SPDX-FileCopyrightText: 2025 Mikko Mononen
 // SPDX-License-Identifier: MIT
 
+#include <string.h>
 #include "test_macros.h"
 #include "skb_editor.h"
+#include "skb_font_collection.h"
 
 static int test_init(void)
 {
@@ -28,8 +30,384 @@ static int test_init(void)
 	return 0;
 }
 
+static int test_command_line_navigation_macos(void)
+{
+	skb_temp_alloc_t* temp_alloc = skb_temp_alloc_create(1024);
+	ENSURE(temp_alloc != NULL);
+
+	skb_font_collection_t* font_collection = skb_font_collection_create();
+	ENSURE(font_collection != NULL);
+	skb_font_handle_t font_handle = skb_font_collection_add_font(font_collection, "data/IBMPlexSans-Regular.ttf", SKB_FONT_FAMILY_DEFAULT);
+	ENSURE(font_handle);
+
+	skb_attribute_t attributes[] = {
+		skb_attribute_make_font(SKB_FONT_FAMILY_DEFAULT, 15.f, SKB_WEIGHT_NORMAL, SKB_STYLE_NORMAL, SKB_STRETCH_NORMAL),
+	};
+
+	skb_editor_params_t params = {
+		 .layout_params = {
+		 	.font_collection = font_collection,
+		 },
+		.text_attributes = attributes,
+		.text_attributes_count = SKB_COUNTOF(attributes),
+		.base_direction = SKB_DIRECTION_LTR,
+		.caret_mode = SKB_CARET_MODE_SKRIBIDI,
+		.jump_mode = SKB_JUMP_MODE_MACOS,
+	};
+
+	skb_editor_t* editor = skb_editor_create(&params);
+	ENSURE(editor != NULL);
+
+	// Initialize editor with test text
+	const char* test_text = "Hello world\nThis is a test\nabout line jumping";
+	skb_editor_set_text_utf8(editor, temp_alloc, test_text, (int32_t)strlen(test_text));
+
+	// Get initial selection - should be at document start
+	skb_text_selection_t initial_selection = skb_editor_get_current_selection(editor);
+	ENSURE(initial_selection.start_pos.offset == 0);
+	ENSURE(initial_selection.end_pos.offset == 0);
+
+	// Test Command+Right (should jump to end of line on macOS)
+	skb_temp_alloc_reset(temp_alloc);
+	skb_editor_process_key_pressed(editor, temp_alloc, SKB_KEY_RIGHT, SKB_MOD_COMMAND);
+	
+	skb_text_selection_t after_command_right = skb_editor_get_current_selection(editor);
+	// Should be at end of first line (position 11, after "Hello world")
+	ENSURE(after_command_right.start_pos.offset == 11);
+	ENSURE(after_command_right.end_pos.offset == 11);
+
+	// Test Command+Left (should jump to beginning of line on macOS)
+	skb_temp_alloc_reset(temp_alloc);
+	skb_editor_process_key_pressed(editor, temp_alloc, SKB_KEY_LEFT, SKB_MOD_COMMAND);
+	
+	skb_text_selection_t after_command_left = skb_editor_get_current_selection(editor);
+	// Should be back at beginning of line (position 0)
+	ENSURE(after_command_left.start_pos.offset == 0);
+	ENSURE(after_command_left.end_pos.offset == 0);
+
+	skb_editor_destroy(editor);
+	skb_font_collection_destroy(font_collection);
+	skb_temp_alloc_destroy(temp_alloc);
+
+	return 0;
+}
+
+static int test_command_document_navigation_macos(void)
+{
+	skb_temp_alloc_t* temp_alloc = skb_temp_alloc_create(1024);
+	ENSURE(temp_alloc != NULL);
+
+	skb_font_collection_t* font_collection = skb_font_collection_create();
+	ENSURE(font_collection != NULL);
+	skb_font_handle_t font_handle = skb_font_collection_add_font(font_collection, "data/IBMPlexSans-Regular.ttf", SKB_FONT_FAMILY_DEFAULT);
+	ENSURE(font_handle);
+
+	skb_attribute_t attributes[] = {
+		skb_attribute_make_font(SKB_FONT_FAMILY_DEFAULT, 15.f, SKB_WEIGHT_NORMAL, SKB_STYLE_NORMAL, SKB_STRETCH_NORMAL),
+	};
+
+	skb_editor_params_t params = {
+		 .layout_params = {
+		 	.font_collection = font_collection,
+		 },
+		.text_attributes = attributes,
+		.text_attributes_count = SKB_COUNTOF(attributes),
+		.base_direction = SKB_DIRECTION_LTR,
+		.caret_mode = SKB_CARET_MODE_SKRIBIDI,
+		.jump_mode = SKB_JUMP_MODE_MACOS,
+	};
+
+	skb_editor_t* editor = skb_editor_create(&params);
+	ENSURE(editor != NULL);
+
+	// Initialize editor with test text
+	const char* test_text = "Hello world\nThis is a test\nabout line jumping";
+	skb_editor_set_text_utf8(editor, temp_alloc, test_text, (int32_t)strlen(test_text));
+
+	// Get initial selection - should be at document start
+	skb_text_selection_t initial_selection = skb_editor_get_current_selection(editor);
+	ENSURE(initial_selection.start_pos.offset == 0);
+	ENSURE(initial_selection.end_pos.offset == 0);
+
+	// Test Command+Down (should navigate to document end on macOS)
+	skb_temp_alloc_reset(temp_alloc);
+	skb_editor_process_key_pressed(editor, temp_alloc, SKB_KEY_DOWN, SKB_MOD_COMMAND);
+	
+	skb_text_selection_t after_command_down = skb_editor_get_current_selection(editor);
+	int32_t expected_end = (int32_t)strlen(test_text);
+	ENSURE(after_command_down.start_pos.offset == expected_end);
+	ENSURE(after_command_down.end_pos.offset == expected_end);
+
+	// Test Command+Up (should navigate to document start on macOS)
+	skb_temp_alloc_reset(temp_alloc);
+	skb_editor_process_key_pressed(editor, temp_alloc, SKB_KEY_UP, SKB_MOD_COMMAND);
+	
+	skb_text_selection_t after_command_up = skb_editor_get_current_selection(editor);
+	ENSURE(after_command_up.start_pos.offset == 0);
+	ENSURE(after_command_up.end_pos.offset == 0);
+
+	// Position caret in the middle of the document for more comprehensive testing
+	skb_text_position_t middle_pos = {.offset = 20, .affinity = SKB_AFFINITY_TRAILING}; // Around "This is a test"
+	skb_text_selection_t middle_selection = {.start_pos = middle_pos, .end_pos = middle_pos};
+	skb_editor_select(editor, middle_selection);
+
+	skb_text_selection_t middle_check = skb_editor_get_current_selection(editor);
+	ENSURE(middle_check.start_pos.offset == 20);
+	ENSURE(middle_check.end_pos.offset == 20);
+
+	// Test Command+Up from middle (should go to document start)
+	skb_temp_alloc_reset(temp_alloc);
+	skb_editor_process_key_pressed(editor, temp_alloc, SKB_KEY_UP, SKB_MOD_COMMAND);
+	
+	skb_text_selection_t from_middle_up = skb_editor_get_current_selection(editor);
+	ENSURE(from_middle_up.start_pos.offset == 0);
+	ENSURE(from_middle_up.end_pos.offset == 0);
+
+	// Reset to middle position
+	skb_editor_select(editor, middle_selection);
+
+	// Test Command+Down from middle (should go to document end)
+	skb_temp_alloc_reset(temp_alloc);
+	skb_editor_process_key_pressed(editor, temp_alloc, SKB_KEY_DOWN, SKB_MOD_COMMAND);
+	
+	skb_text_selection_t from_middle_down = skb_editor_get_current_selection(editor);
+	ENSURE(from_middle_down.start_pos.offset == expected_end);
+	ENSURE(from_middle_down.end_pos.offset == expected_end);
+
+	skb_editor_destroy(editor);
+	skb_font_collection_destroy(font_collection);
+	skb_temp_alloc_destroy(temp_alloc);
+
+	return 0;
+}
+
+static int test_shift_command_text_selection_macos(void)
+{
+	skb_temp_alloc_t* temp_alloc = skb_temp_alloc_create(1024);
+	ENSURE(temp_alloc != NULL);
+
+	skb_font_collection_t* font_collection = skb_font_collection_create();
+	ENSURE(font_collection != NULL);
+	skb_font_handle_t font_handle = skb_font_collection_add_font(font_collection, "data/IBMPlexSans-Regular.ttf", SKB_FONT_FAMILY_DEFAULT);
+	ENSURE(font_handle);
+
+	skb_attribute_t attributes[] = {
+		skb_attribute_make_font(SKB_FONT_FAMILY_DEFAULT, 15.f, SKB_WEIGHT_NORMAL, SKB_STYLE_NORMAL, SKB_STRETCH_NORMAL),
+	};
+
+	skb_editor_params_t params = {
+		 .layout_params = {
+		 	.font_collection = font_collection,
+		 },
+		.text_attributes = attributes,
+		.text_attributes_count = SKB_COUNTOF(attributes),
+		.base_direction = SKB_DIRECTION_LTR,
+		.caret_mode = SKB_CARET_MODE_SKRIBIDI,
+		.jump_mode = SKB_JUMP_MODE_MACOS,
+	};
+
+	skb_editor_t* editor = skb_editor_create(&params);
+	ENSURE(editor != NULL);
+
+	// Initialize editor with test text
+	const char* test_text = "Hello world\nThis is a test\nabout line jumping";
+	skb_editor_set_text_utf8(editor, temp_alloc, test_text, (int32_t)strlen(test_text));
+
+	// Get initial selection - should be at document start
+	skb_text_selection_t initial_selection = skb_editor_get_current_selection(editor);
+	ENSURE(initial_selection.start_pos.offset == 0);
+	ENSURE(initial_selection.end_pos.offset == 0);
+
+	// Test Shift+Command+Down (should select from start to document end)
+	skb_temp_alloc_reset(temp_alloc);
+	skb_editor_process_key_pressed(editor, temp_alloc, SKB_KEY_DOWN, SKB_MOD_SHIFT | SKB_MOD_COMMAND);
+	
+	skb_text_selection_t full_selection = skb_editor_get_current_selection(editor);
+	int32_t expected_end = (int32_t)strlen(test_text);
+	ENSURE(full_selection.start_pos.offset == 0);
+	ENSURE(full_selection.end_pos.offset == expected_end);
+
+	// Reset to end position and test Shift+Command+Up (should select from end to document start)
+	skb_text_position_t end_pos = {.offset = expected_end, .affinity = SKB_AFFINITY_TRAILING};
+	skb_text_selection_t end_selection = {.start_pos = end_pos, .end_pos = end_pos};
+	skb_editor_select(editor, end_selection);
+
+	skb_text_selection_t end_check = skb_editor_get_current_selection(editor);
+	ENSURE(end_check.start_pos.offset == expected_end);
+	ENSURE(end_check.end_pos.offset == expected_end);
+
+	skb_temp_alloc_reset(temp_alloc);
+	skb_editor_process_key_pressed(editor, temp_alloc, SKB_KEY_UP, SKB_MOD_SHIFT | SKB_MOD_COMMAND);
+	
+	skb_text_selection_t reverse_selection = skb_editor_get_current_selection(editor);
+	// Should select from end to start
+	ENSURE((reverse_selection.start_pos.offset == 0 && reverse_selection.end_pos.offset == expected_end) ||
+	       (reverse_selection.start_pos.offset == expected_end && reverse_selection.end_pos.offset == 0));
+
+	// Reset to start position for line-level testing
+	skb_text_position_t start_pos = {.offset = 0, .affinity = SKB_AFFINITY_TRAILING};
+	skb_text_selection_t start_selection = {.start_pos = start_pos, .end_pos = start_pos};
+	skb_editor_select(editor, start_selection);
+
+	skb_text_selection_t reset_check = skb_editor_get_current_selection(editor);
+	ENSURE(reset_check.start_pos.offset == 0);
+	ENSURE(reset_check.end_pos.offset == 0);
+
+	// Test Shift+Command+Right (should select from start to end of line)
+	skb_temp_alloc_reset(temp_alloc);
+	skb_editor_process_key_pressed(editor, temp_alloc, SKB_KEY_RIGHT, SKB_MOD_SHIFT | SKB_MOD_COMMAND);
+	
+	skb_text_selection_t line_selection = skb_editor_get_current_selection(editor);
+	// Should select from position 0 to end of first line (position 11, after "Hello world")
+	ENSURE(line_selection.start_pos.offset == 0);
+	ENSURE(line_selection.end_pos.offset == 11);
+
+	// Test Shift+Command+Left (should select from current position to start of line)
+	// First move to end of first line
+	skb_text_position_t end_line_pos = {.offset = 11, .affinity = SKB_AFFINITY_TRAILING};
+	skb_text_selection_t end_line_selection = {.start_pos = end_line_pos, .end_pos = end_line_pos};
+	skb_editor_select(editor, end_line_selection);
+
+	skb_text_selection_t end_line_check = skb_editor_get_current_selection(editor);
+	ENSURE(end_line_check.start_pos.offset == 11);
+	ENSURE(end_line_check.end_pos.offset == 11);
+
+	skb_temp_alloc_reset(temp_alloc);
+	skb_editor_process_key_pressed(editor, temp_alloc, SKB_KEY_LEFT, SKB_MOD_SHIFT | SKB_MOD_COMMAND);
+	
+	skb_text_selection_t reverse_line_selection = skb_editor_get_current_selection(editor);
+	// Should select from position 11 back to position 0
+	ENSURE((reverse_line_selection.start_pos.offset == 0 && reverse_line_selection.end_pos.offset == 11) ||
+	       (reverse_line_selection.start_pos.offset == 11 && reverse_line_selection.end_pos.offset == 0));
+
+	skb_editor_destroy(editor);
+	skb_font_collection_destroy(font_collection);
+	skb_temp_alloc_destroy(temp_alloc);
+
+	return 0;
+}
+
+static int test_option_word_navigation_macos(void)
+{
+	skb_temp_alloc_t* temp_alloc = skb_temp_alloc_create(1024);
+	ENSURE(temp_alloc != NULL);
+
+	skb_font_collection_t* font_collection = skb_font_collection_create();
+	ENSURE(font_collection != NULL);
+	skb_font_handle_t font_handle = skb_font_collection_add_font(font_collection, "data/IBMPlexSans-Regular.ttf", SKB_FONT_FAMILY_DEFAULT);
+	ENSURE(font_handle);
+
+	skb_attribute_t attributes[] = {
+		skb_attribute_make_font(SKB_FONT_FAMILY_DEFAULT, 15.f, SKB_WEIGHT_NORMAL, SKB_STYLE_NORMAL, SKB_STRETCH_NORMAL),
+	};
+
+	skb_editor_params_t params = {
+		 .layout_params = {
+		 	.font_collection = font_collection,
+		 },
+		.text_attributes = attributes,
+		.text_attributes_count = SKB_COUNTOF(attributes),
+		.base_direction = SKB_DIRECTION_LTR,
+		.caret_mode = SKB_CARET_MODE_SKRIBIDI,
+		.jump_mode = SKB_JUMP_MODE_MACOS,
+	};
+
+	skb_editor_t* editor = skb_editor_create(&params);
+	ENSURE(editor != NULL);
+
+	// Initialize editor with test text
+	const char* test_text = "Hello world\nThis is a test\nabout line jumping";
+	skb_editor_set_text_utf8(editor, temp_alloc, test_text, (int32_t)strlen(test_text));
+
+	// Get initial selection - should be at document start
+	skb_text_selection_t initial_selection = skb_editor_get_current_selection(editor);
+	ENSURE(initial_selection.start_pos.offset == 0);
+	ENSURE(initial_selection.end_pos.offset == 0);
+
+	// Test Option+Right (should jump to next word boundary)
+	skb_temp_alloc_reset(temp_alloc);
+	skb_editor_process_key_pressed(editor, temp_alloc, SKB_KEY_RIGHT, SKB_MOD_OPTION);
+	
+	skb_text_selection_t after_first_jump = skb_editor_get_current_selection(editor);
+	// Should move to next word boundary (position depends on word boundary algorithm)
+	ENSURE(after_first_jump.start_pos.offset > 0);
+	ENSURE(after_first_jump.start_pos.offset == after_first_jump.end_pos.offset);
+	int32_t first_word_end = after_first_jump.start_pos.offset;
+
+	// Test Option+Right again (should jump to next word)
+	skb_temp_alloc_reset(temp_alloc);
+	skb_editor_process_key_pressed(editor, temp_alloc, SKB_KEY_RIGHT, SKB_MOD_OPTION);
+	
+	skb_text_selection_t after_second_jump = skb_editor_get_current_selection(editor);
+	ENSURE(after_second_jump.start_pos.offset > first_word_end);
+	ENSURE(after_second_jump.start_pos.offset == after_second_jump.end_pos.offset);
+	int32_t second_word_end = after_second_jump.start_pos.offset;
+
+	// Test Option+Left (should jump back to previous word boundary)
+	skb_temp_alloc_reset(temp_alloc);
+	skb_editor_process_key_pressed(editor, temp_alloc, SKB_KEY_LEFT, SKB_MOD_OPTION);
+	
+	skb_text_selection_t after_left_jump = skb_editor_get_current_selection(editor);
+	ENSURE(after_left_jump.start_pos.offset < second_word_end);
+	ENSURE(after_left_jump.start_pos.offset == after_left_jump.end_pos.offset);
+
+	// Test Option+Left again (should jump back further)
+	skb_temp_alloc_reset(temp_alloc);
+	skb_editor_process_key_pressed(editor, temp_alloc, SKB_KEY_LEFT, SKB_MOD_OPTION);
+	
+	skb_text_selection_t after_second_left = skb_editor_get_current_selection(editor);
+	ENSURE(after_second_left.start_pos.offset < after_left_jump.start_pos.offset);
+	ENSURE(after_second_left.start_pos.offset == after_second_left.end_pos.offset);
+
+	// Reset to start and test Shift+Option+Right (should select word)
+	skb_text_position_t start_pos = {.offset = 0, .affinity = SKB_AFFINITY_TRAILING};
+	skb_text_selection_t start_selection = {.start_pos = start_pos, .end_pos = start_pos};
+	skb_editor_select(editor, start_selection);
+
+	skb_text_selection_t reset_check = skb_editor_get_current_selection(editor);
+	ENSURE(reset_check.start_pos.offset == 0);
+	ENSURE(reset_check.end_pos.offset == 0);
+
+	skb_temp_alloc_reset(temp_alloc);
+	skb_editor_process_key_pressed(editor, temp_alloc, SKB_KEY_RIGHT, SKB_MOD_SHIFT | SKB_MOD_OPTION);
+	
+	skb_text_selection_t word_selection = skb_editor_get_current_selection(editor);
+	// Should have a selection that spans some text
+	ENSURE(word_selection.start_pos.offset == 0);
+	ENSURE(word_selection.end_pos.offset > 0);
+
+	// Test Shift+Option+Left from a position in the middle
+	// Move to middle of text first
+	skb_text_position_t middle_pos = {.offset = 20, .affinity = SKB_AFFINITY_TRAILING};
+	skb_text_selection_t middle_selection = {.start_pos = middle_pos, .end_pos = middle_pos};
+	skb_editor_select(editor, middle_selection);
+
+	skb_text_selection_t middle_check = skb_editor_get_current_selection(editor);
+	ENSURE(middle_check.start_pos.offset == 20);
+	ENSURE(middle_check.end_pos.offset == 20);
+
+	skb_temp_alloc_reset(temp_alloc);
+	skb_editor_process_key_pressed(editor, temp_alloc, SKB_KEY_LEFT, SKB_MOD_SHIFT | SKB_MOD_OPTION);
+	
+	skb_text_selection_t reverse_word_selection = skb_editor_get_current_selection(editor);
+	// Should have a selection going backwards
+	ENSURE(reverse_word_selection.start_pos.offset != reverse_word_selection.end_pos.offset);
+	ENSURE((reverse_word_selection.start_pos.offset == 20 && reverse_word_selection.end_pos.offset < 20) ||
+	       (reverse_word_selection.start_pos.offset < 20 && reverse_word_selection.end_pos.offset == 20));
+
+	skb_editor_destroy(editor);
+	skb_font_collection_destroy(font_collection);
+	skb_temp_alloc_destroy(temp_alloc);
+
+	return 0;
+}
+
 int editor_tests(void)
 {
 	RUN_SUBTEST(test_init);
+	RUN_SUBTEST(test_command_line_navigation_macos);
+	RUN_SUBTEST(test_command_document_navigation_macos);
+	RUN_SUBTEST(test_shift_command_text_selection_macos);
+	RUN_SUBTEST(test_option_word_navigation_macos);
 	return 0;
 }

--- a/test/test_editor.c
+++ b/test/test_editor.c
@@ -52,7 +52,7 @@ static int test_command_line_navigation_macos(void)
 		.text_attributes_count = SKB_COUNTOF(attributes),
 		.base_direction = SKB_DIRECTION_LTR,
 		.caret_mode = SKB_CARET_MODE_SKRIBIDI,
-		.jump_mode = SKB_JUMP_MODE_MACOS,
+		.editor_behavior = SKB_BEHAVIOR_MACOS,
 	};
 
 	skb_editor_t* editor = skb_editor_create(&params);
@@ -114,7 +114,7 @@ static int test_command_document_navigation_macos(void)
 		.text_attributes_count = SKB_COUNTOF(attributes),
 		.base_direction = SKB_DIRECTION_LTR,
 		.caret_mode = SKB_CARET_MODE_SKRIBIDI,
-		.jump_mode = SKB_JUMP_MODE_MACOS,
+		.editor_behavior = SKB_BEHAVIOR_MACOS,
 	};
 
 	skb_editor_t* editor = skb_editor_create(&params);
@@ -203,7 +203,7 @@ static int test_shift_command_text_selection_macos(void)
 		.text_attributes_count = SKB_COUNTOF(attributes),
 		.base_direction = SKB_DIRECTION_LTR,
 		.caret_mode = SKB_CARET_MODE_SKRIBIDI,
-		.jump_mode = SKB_JUMP_MODE_MACOS,
+		.editor_behavior = SKB_BEHAVIOR_MACOS,
 	};
 
 	skb_editor_t* editor = skb_editor_create(&params);
@@ -309,7 +309,7 @@ static int test_option_word_navigation_macos(void)
 		.text_attributes_count = SKB_COUNTOF(attributes),
 		.base_direction = SKB_DIRECTION_LTR,
 		.caret_mode = SKB_CARET_MODE_SKRIBIDI,
-		.jump_mode = SKB_JUMP_MODE_MACOS,
+		.editor_behavior = SKB_BEHAVIOR_MACOS,
 	};
 
 	skb_editor_t* editor = skb_editor_create(&params);


### PR DESCRIPTION
Added some text editor navigation that feels native to MacOS:
- Command+left/right acts like home and end
- Command+up/down jumps to the beginning and end of the whole text.
- Option+left/right jumps to the beginning and end of words.

I've tried to be consistent with MacOS behavior, and it feels right, but I'm not sure that all nuances are covered. I'm also not sure that I've gotten the affinity leading/trailing stuff correct. It would be really great if you could have a look. I'm also skipping Option+up/down behavior, which jumps to the end of paragraphs because it is relatively complex behavior in MacOS, and is not implemented consistently in all apps (e.g. even FireFox seems to get it wrong). I think this can be carefully added in later.

I've also added some tests for this.