### PR TITLE
Avoid HB null pointer deref when creating font from null data

### DIFF
--- a/src/skb_font_collection.c
+++ b/src/skb_font_collection.c
@@ -283,6 +283,8 @@ static bool skb__font_create_from_data(
 
 	// skb_debug_log("Loading font from data: %s\n", name);
 
+	if (!font_data) goto error;
+
 	// Use Harfbuzz to create blob from memory data with read-only mode
 	// Pass the context and destroy function to HarfBuzz so it can manage the lifetime
 	blob = hb_blob_create_or_fail((const char*)font_data, (unsigned int)font_data_length, HB_MEMORY_MODE_READONLY, context, (hb_destroy_func_t)destroy_func);


### PR DESCRIPTION
When running the new `test_add_font_failures` with UBSan enabled, the "Null data" test crashes.

```sh
  subtest passed: test_init
  subtest passed: test_add_remove
  subtest passed: test_add_font_from_data
/dev/Skribidi/build/_deps/harfbuzz-src/src/hb-face.cc:89:7: runtime error: member call on null pointer of type 'OT::OpenTypeFontFile'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /dev/Skribidi/build/_deps/harfbuzz-src/src/hb-face.cc:89:7 
```

It seems that `hb_face_create_or_fail` does not check `blob->data` is non-null, leading to `hb_face_count` performing a member call on a null pointer:

```C++
unsigned int
hb_face_count (hb_blob_t *blob)
{
  if (unlikely (!blob))
    return 0;

  hb_sanitize_context_t c (blob);

  const char *start = hb_blob_get_data (blob, nullptr);  // <-- returns null 
  auto *ot = reinterpret_cast<OT::OpenTypeFontFile *> (const_cast<char *> (start));
  if (unlikely (!ot->sanitize (&c)))                     // <-- sanitize called on null pointer
    return 0;
```

To avoid this, I've added an early return to `skb__font_create_from_data` in the case that `font_data` is null.