### PR TITLE
Added SKB_NO_OPEN config option

### DIFF
--- a/include/skb_common.h
+++ b/include/skb_common.h
@@ -90,6 +90,9 @@ void* skb_realloc(void* ptr, size_t new_size);
  */
 void skb_free(void* ptr);
 
+/** Signature of destroy function */
+typedef void skb_destroy_func_t(void *context);
+
 /**
  * Helper macro to reserve space in an allocated array.
  * The macro relies on naming convention, if your array is called 'apples', then it is expected

--- a/include/skb_font_collection.h
+++ b/include/skb_font_collection.h
@@ -214,27 +214,9 @@ void skb_font_collection_destroy(skb_font_collection_t* font_collection);
 void skb_font_collection_set_on_font_fallback(skb_font_collection_t* font_collection, skb_font_fallback_func_t* fallback_func, void* context);
 
 /**
- * Adds OTF or TTF font to the collection.
- * @param font_collection font collection to use.
- * @param file_name file name of the font to add.
- * @param font_family font family identifier.
- * @return pointer to the added font, on NULL if failed to load the font.
- */
-skb_font_handle_t skb_font_collection_add_font(skb_font_collection_t* font_collection, const char* file_name, uint8_t font_family);
-
-/**
- * Removes font from the collection.
- * @param font_collection font collection to change.
- * @param font_handle handle to the font to remove.
- * @return true if the remove succeeded.
- */
-bool skb_font_collection_remove_font(skb_font_collection_t* font_collection, skb_font_handle_t font_handle);
-
-/** Signature of destroy function */
-typedef void skb_destroy_func_t(void *context);
-
-/**
  * Adds OTF or TTF font to the collection from memory.
+ * The font collection retains a reference to the data until skb_font_collection_remove_font() or skb_font_collection_destroy is called.
+ * The destroy_func() is called with the provided context pointer when the data is destroyed.
  * @param font_collection font collection to use.
  * @param name used to uniquely identify the font.
  * @param font_family font family identifier.
@@ -253,6 +235,25 @@ skb_font_handle_t skb_font_collection_add_font_from_data(
 	void* context,
 	skb_destroy_func_t* destroy_func
 );
+
+#if !defined(SKB_NO_OPEN)
+/**
+ * Adds OTF or TTF font to the collection.
+ * @param font_collection font collection to use.
+ * @param file_name file name of the font to add.
+ * @param font_family font family identifier.
+ * @return pointer to the added font, on NULL if failed to load the font.
+ */
+skb_font_handle_t skb_font_collection_add_font(skb_font_collection_t* font_collection, const char* file_name, uint8_t font_family);
+#endif
+
+/**
+ * Removes font from the collection.
+ * @param font_collection font collection to change.
+ * @param font_handle handle to the font to remove.
+ * @return true if the remove succeeded.
+ */
+bool skb_font_collection_remove_font(skb_font_collection_t* font_collection, skb_font_handle_t font_handle);
 
 /**
  * Returns fonts matching specific font properties.

--- a/include/skb_icon_collection.h
+++ b/include/skb_icon_collection.h
@@ -47,6 +47,18 @@ skb_icon_collection_t* skb_icon_collection_create(void);
 void skb_icon_collection_destroy(skb_icon_collection_t* icon_collection);
 
 /**
+ * Adds PicoSVG to the icon collection from memory.
+ * Note: the icon is parsed during the function and icon_data is not stored for later use.
+ * @param icon_collection icon collection to use.
+ * @param name name of the icon (used for querying).
+ * @param icon_data pointer to the icon data to add.
+ * @param icon_data_length length of the data in icon_data in bytes.
+ * @return pointer to the added icon, or NULL if failed.
+ */
+skb_icon_handle_t skb_icon_collection_add_picosvg_icon_from_data(skb_icon_collection_t* icon_collection, const char* name, const char* icon_data, const int32_t icon_data_length);
+
+#if !defined(SKB_NO_OPEN)
+/**
  * Adds PicoSVG to the icon collection.
  * @param icon_collection icon collection to use.
  * @param name name of the icon (used for querying).
@@ -54,6 +66,7 @@ void skb_icon_collection_destroy(skb_icon_collection_t* icon_collection);
  * @return pointer to the added icon, or NULL if failed.
  */
 skb_icon_handle_t skb_icon_collection_add_picosvg_icon(skb_icon_collection_t* icon_collection, const char* name, const char* file_name);
+#endif // !defined(SKB_NO_OPEN)
 
 /**
  * Adds an empty icon of specified name and size.

--- a/src/skb_font_collection.c
+++ b/src/skb_font_collection.c
@@ -246,6 +246,7 @@ error:
 	return false;
 }
 
+#if !defined(SKB_NO_OPEN)
 static bool skb__font_create(skb_font_t* font, const char* path, uint8_t font_family)
 {
 	hb_blob_t* blob = NULL;
@@ -272,6 +273,7 @@ error:
 	hb_face_destroy(face);
 	return false;
 }
+#endif // !defined(SKB_NO_OPEN)
 
 static bool skb__font_create_from_data(
 	skb_font_t* font,
@@ -344,6 +346,7 @@ void skb_font_collection_set_on_font_fallback(skb_font_collection_t* font_collec
 	font_collection->fallback_context = context;
 }
 
+#if !defined(SKB_NO_OPEN)
 skb_font_handle_t skb_font_collection_add_font(skb_font_collection_t* font_collection, const char* file_name, uint8_t font_family)
 {
 	// Try to find free slot.
@@ -378,6 +381,7 @@ skb_font_handle_t skb_font_collection_add_font(skb_font_collection_t* font_colle
 
 	return font->handle;
 }
+#endif // !defined SKB_NO_OPEN
 
 skb_font_handle_t skb_font_collection_add_font_from_data(
 	skb_font_collection_t* font_collection,

--- a/test/test_font_collection.c
+++ b/test/test_font_collection.c
@@ -4,7 +4,6 @@
 #include "test_macros.h"
 #include "skb_font_collection.h"
 #include "skb_layout.h"
-#include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
 


### PR DESCRIPTION
SKB_NO_OPEN can be used to disable the file open based font and icon loaders. #69