### PR TITLE
Fix for syntax differences C vs C++

### DIFF
--- a/example/render.h
+++ b/example/render.h
@@ -221,7 +221,7 @@ typedef struct render_override_slice_t {
 	int32_t count;
 } render_override_slice_t;
 
-#define RENDER_OVERRIDE_SLICE_FROM_ARRAY(array) skb_new(render_override_slice_t) { .items = (array), .count = SKB_COUNTOF(array) }
+#define RENDER_OVERRIDE_SLICE_FROM_ARRAY(array) SKB_NEW(render_override_slice_t) { .items = (array), .count = SKB_COUNTOF(array) }
 
 render_override_t render_color_override_make_fill(intptr_t content_data, skb_color_t color);
 render_override_t render_color_override_make_decoration(intptr_t content_data, skb_color_t color);

--- a/include/skb_attributes.h
+++ b/include/skb_attributes.h
@@ -535,7 +535,7 @@ typedef struct skb_attribute_set_t {
 	const struct skb_attribute_set_t* parent_set;
 } skb_attribute_set_t;
 
-#define SKB_ATTRIBUTE_SET_FROM_STATIC_ARRAY(array) skb_new(skb_attribute_set_t) { .attributes = (array), .attributes_count = SKB_COUNTOF(array) }
+#define SKB_ATTRIBUTE_SET_FROM_STATIC_ARRAY(array) SKB_NEW(skb_attribute_set_t) { .attributes = (array), .attributes_count = SKB_COUNTOF(array) }
 
 /** Creates attribute set that is a reference to specified set in a collection. */
 skb_attribute_set_t skb_attribute_set_make_reference(skb_attribute_set_handle_t handle);

--- a/include/skb_common.h
+++ b/include/skb_common.h
@@ -19,9 +19,9 @@ extern "C" {
 * when instantiating structs.
 */
 #if defined(__cplusplus__)
-#define skb_new(type) type
+#define SKB_NEW(type) type
 #else
-#define skb_new(type) (type)
+#define SKB_NEW(type) (type)
 #endif
 
 


### PR DESCRIPTION
When including skb header files in C++ some macros do not work because of subtle differences in C vs C++ syntax.
I added a mechanism to fix this so it works in both C and C++