### PR TITLE
Only link against math library on non-Windows platforms

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -161,7 +161,7 @@ set_target_properties(skribidi PROPERTIES
 	DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX}
 )
 
-if(NOT MSVC)
+if(NOT WIN32)
 	target_link_libraries(skribidi PUBLIC m)
 endif()
 


### PR DESCRIPTION
The CMake file uses `NOT MSVC` to detect whether to link `m`. This breaks when cross-compiling from Linux to Windows: We should really check `NOT WIN32` instead, because a non-MSVC compiler can be used to still target Windows.