### PR TITLE
Add partial blend-mode support to canvas. Fixes #90

### DIFF
--- a/include/skb_canvas.h
+++ b/include/skb_canvas.h
@@ -71,6 +71,24 @@ typedef struct skb_color_stop_t {
 } skb_color_stop_t;
 
 /**
+ * Defines the supported blend modes when compositing layers
+ * Enum values match the CompositeMode values defined in
+ * https://learn.microsoft.com/en-us/typography/opentype/spec/colr#format-32-paintcomposite
+ */
+typedef enum {
+	SKB_BLEND_CLEAR = 0,
+	SKB_BLEND_SRC = 1,
+	SKB_BLEND_DEST = 2,
+	SKB_BLEND_SRC_OVER = 3,
+	SKB_BLEND_DEST_OVER = 4,
+	SKB_BLEND_SRC_IN = 5,
+	SKB_BLEND_DEST_IN = 6,
+	SKB_BLEND_SRC_OUT = 7,
+	SKB_BLEND_DEST_OUT = 8,
+	SKB_BLEND_SOFT_LIGHT = 20,
+} skb_blend_mode_t;
+
+/**
  * Creates new canvas to draw to.
  * The canvas is expected to be disposable. You create canvas, draw some shapes, and dispose it.
  * The canvas will hold on to the temp allocator until skb_canvas_destroy() is called.
@@ -164,8 +182,9 @@ void skb_canvas_push_layer(skb_canvas_t* c);
 /**
  * Removes the image layer from the top of the layer stack and blends it over the previous image.
  * @param c canvas to draw to
+ * @param mode the blend mode to use for compositing
  */
-void skb_canvas_pop_layer(skb_canvas_t* c);
+void skb_canvas_pop_layer(skb_canvas_t* c, skb_blend_mode_t mode);
 
 /**
  * Rasterizes the vector shape defined earlier into the top of the mask stack.

--- a/src/skb_rasterizer.c
+++ b/src/skb_rasterizer.c
@@ -761,11 +761,8 @@ static void skb__hb_pop_group (
 
 	skb_canvas_t* c = (skb_canvas_t*)paint_data;
 
-	if (mode != HB_PAINT_COMPOSITE_MODE_SRC_OVER) {
-		skb_debug_log("Unsupported blend mode: %d\n", mode);
-	}
-
-	skb_canvas_pop_layer(c);
+	// Note: Simple mode conversion possible because HB and SKB enum values both exactly match the COLRv1 spec.
+	skb_canvas_pop_layer(c, (skb_blend_mode_t)mode);
 }
 
 #define GRAST_MAX_COLOR_STOPS 64
@@ -1159,7 +1156,7 @@ static void skb__icon_draw_shape(skb_canvas_t* c, const skb_icon_t* icon, const 
 			skb_canvas_fill_solid_color(c, color);
 		}
 
-		skb_canvas_pop_layer(c);
+		skb_canvas_pop_layer(c, SKB_BLEND_SRC_OVER);
 	}
 
 	for (int32_t i = 0; i < shape->children_count; i++)


### PR DESCRIPTION
Support for the following blend-modes has been added to canvas and passed in by the rasterizer.
```
SKB_BLEND_CLEAR
SKB_BLEND_SRC
SKB_BLEND_DEST
SKB_BLEND_SRC_OVER
SKB_BLEND_DEST_OVER
SKB_BLEND_SRC_IN
SKB_BLEND_DEST_IN
SKB_BLEND_SRC_OUT
SKB_BLEND_DEST_OUT
SKB_BLEND_SOFT_LIGHT
```
Now 10 of the 27 blend modes are supported.

### Example using SRC_IN and SOFT_LIGHT

*Before*
<img width="470" height="77" alt="Image" src="https://github.com/user-attachments/assets/c8925ae2-a80a-4a10-ba2e-0bcf6e6c43e0" />
*After*
<img width="482" height="82" alt="Screenshot 2026-01-20 at 03 26 27" src="https://github.com/user-attachments/assets/e2ebbe5c-bd15-4082-936c-6024625713bd" />

_Notes:_
* The *after* image above is still not 100% correct for these flags (from Noto Color Emoji), but I think that is due to a different issue, with the gradients used on those blend-layers.
* Additional optimization is definitely possible.
* Existing Icon behaviour is preserved by passing explicit `SRC_OVER` blend-mode.
