### PR TITLE
Fix example build on MinGW

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -58,7 +58,7 @@ target_include_directories(skribidi_example PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} 
 target_link_libraries(skribidi_example PUBLIC glfw skribidi harfbuzz)
 
 # IME only works on Windows for now.
-if(MSVC)
+if(WIN32)
     target_link_libraries(skribidi_example PUBLIC imm32.lib comctl32.lib)
 endif()
 


### PR DESCRIPTION
The MSVC check causes linking on Windows to fail with other toolchains. Replacing it with a more general Windows target check resolves it.

Tested with both MSYS2 CLANG64 and MSYS2 MINGW64 (also VS2022, for a good measure).