### PR TITLE
Fix skb_ceilf rounding bug for integer font sizes >= 33

### DIFF
--- a/include/skb_common.h
+++ b/include/skb_common.h
@@ -142,9 +142,7 @@ static inline int32_t skb_round_to_int(float x)
 
 static inline float skb_ceilf(float x)
 {
-	x -= 0.000001f; // To break the even-odd rounding
-	const int32_t ix = (int32_t)x;
-	return x < 0.f ? (float)ix : (float)(ix+1);
+	return ceilf(x);
 }
 
 static inline float skb_floorf(float x)

--- a/test/test_render_cache.c
+++ b/test/test_render_cache.c
@@ -3,6 +3,7 @@
 
 #include "test_macros.h"
 #include "skb_render_cache.h"
+#include "skb_common.h"
 
 static int test_init(void)
 {
@@ -14,8 +15,34 @@ static int test_init(void)
 	return 0;
 }
 
+static int test_ceilf_rounding(void)
+{
+	// Integer font sizes must remain unchanged
+	ENSURE_SMALL(skb_ceilf(48.0f) - 48.0f, 1e-6f);
+	ENSURE_SMALL(skb_ceilf(33.0f) - 33.0f, 1e-6f);
+	ENSURE_SMALL(skb_ceilf(100.0f) - 100.0f, 1e-6f);
+	ENSURE_SMALL(skb_ceilf(256.0f) - 256.0f, 1e-6f);
+	ENSURE_SMALL(skb_ceilf(1.0f) - 1.0f, 1e-6f);
+
+	// Non-integer font sizes must round up
+	ENSURE_SMALL(skb_ceilf(48.42f) - 49.0f, 1e-6f);
+	ENSURE_SMALL(skb_ceilf(33.001f) - 34.0f, 1e-6f);
+	ENSURE_SMALL(skb_ceilf(0.5f) - 1.0f, 1e-6f);
+
+	// Very small values
+	ENSURE_SMALL(skb_ceilf(0.001f) - 1.0f, 1e-6f);
+
+	// Negative values (ceil rounds toward positive infinity)
+	ENSURE_SMALL(skb_ceilf(-1.0f) - (-1.0f), 1e-6f);
+	ENSURE_SMALL(skb_ceilf(-1.5f) - (-1.0f), 1e-6f);
+	ENSURE_SMALL(skb_ceilf(-10.75f) - (-10.0f), 1e-6f);
+
+	return 0;
+}
+
 int render_cache_tests(void)
 {
 	RUN_SUBTEST(test_init);
+	RUN_SUBTEST(test_ceilf_rounding);
 	return 0;
 }


### PR DESCRIPTION
## Summary

Fixes a bug in skb_ceilf() where the custom epsilon-based truncation implementation fails for float values >= 33, causing integer font sizes to be incorrectly rounded up (e.g., 48.0f -> 49.0f). This results in render_scale != 1.0 for integer font sizes in alpha mask rendering.

## Root Cause

The function used x -= 0.000001f before truncation. For float32 values >= 33, the ULP (unit in the last place) exceeds 1e-6, making the subtraction a no-op. The value truncates to the same integer and then gets incremented by 1, producing an incorrect ceil result.

## Fix

Replace the fragile epsilon-based implementation with the standard ceilf() from math.h.

## Changes

- include/skb_common.h: skb_ceilf now calls ceilf(x) from math.h
- test/test_render_cache.c: Added test_ceilf_rounding with 12 assertions covering integer, non-integer, small, and negative values
