### PR TITLE
Fix double-free when removing text from a degenerate text range

### DIFF
--- a/include/skb_common.h
+++ b/include/skb_common.h
@@ -220,7 +220,11 @@ typedef struct skb_paragraph_position_t {
 	int32_t paragraph_idx;
 	/** Text offset within the paragraph. */
 	int32_t text_offset;
-	/** Text offset amongst all paragraphs. */
+	/** Text offset amongst all paragraphs. Ambiguous: two positions in different
+	 * paragraphs can share the same global_text_offset (e.g. the end of one
+	 * paragraph and the start of the next). Use this only to map a
+	 * skb_paragraph_position_t to a flat offset, not to test ordering between
+	 * positions; for ordering use skb_paragraph_position_less_than(). */
 	int32_t global_text_offset;
 } skb_paragraph_position_t;
 
@@ -231,6 +235,16 @@ typedef struct skb_paragraph_range_t {
 	/** End position of the range. */
 	skb_paragraph_position_t end;
 } skb_paragraph_range_t;
+
+/** Returns true if a comes strictly before b in document order. Compares by
+ * (paragraph_idx, text_offset); do not compare global_text_offset directly, as
+ * it can tie across paragraph boundaries. */
+static inline bool skb_paragraph_position_less_than(skb_paragraph_position_t a, skb_paragraph_position_t b)
+{
+	if (a.paragraph_idx != b.paragraph_idx)
+		return a.paragraph_idx < b.paragraph_idx;
+	return a.text_offset < b.text_offset;
+}
 
 /**
  * Logs a debug message.

--- a/include/skb_common.h
+++ b/include/skb_common.h
@@ -224,7 +224,7 @@ typedef struct skb_paragraph_position_t {
 	 * paragraphs can share the same global_text_offset (e.g. the end of one
 	 * paragraph and the start of the next). Use this only to map a
 	 * skb_paragraph_position_t to a flat offset, not to test ordering between
-	 * positions; for ordering use skb_paragraph_position_less_than(). */
+	 * positions; for ordering use skb_paragraph_position_less_or_equal(). */
 	int32_t global_text_offset;
 } skb_paragraph_position_t;
 
@@ -236,14 +236,14 @@ typedef struct skb_paragraph_range_t {
 	skb_paragraph_position_t end;
 } skb_paragraph_range_t;
 
-/** Returns true if a comes strictly before b in document order. Compares by
+/** Returns true if a comes at or before b in document order. Compares by
  * (paragraph_idx, text_offset); do not compare global_text_offset directly, as
  * it can tie across paragraph boundaries. */
-static inline bool skb_paragraph_position_less_than(skb_paragraph_position_t a, skb_paragraph_position_t b)
+static inline bool skb_paragraph_position_less_or_equal(skb_paragraph_position_t a, skb_paragraph_position_t b)
 {
 	if (a.paragraph_idx != b.paragraph_idx)
 		return a.paragraph_idx < b.paragraph_idx;
-	return a.text_offset < b.text_offset;
+	return a.text_offset <= b.text_offset;
 }
 
 /**

--- a/src/skb_editor.c
+++ b/src/skb_editor.c
@@ -1083,9 +1083,9 @@ skb_text_position_t skb_editor_get_selection_ordered_start(const skb_editor_t* e
 	skb_paragraph_position_t end_pos = skb_rich_text_get_paragraph_position_from_text_position(&editor->rich_text, text_range.end, SKB_AFFINITY_USE);
 
 	if (skb_is_rtl(skb__get_layout_resolved_direction(editor, end_pos.paragraph_idx)))
-		return skb_paragraph_position_less_than(end_pos, start_pos) ? text_range.start : text_range.end;
+		return skb_paragraph_position_less_or_equal(start_pos, end_pos) ? text_range.end : text_range.start;
 
-	return skb_paragraph_position_less_than(end_pos, start_pos) ? text_range.end : text_range.start;
+	return skb_paragraph_position_less_or_equal(start_pos, end_pos) ? text_range.start : text_range.end;
 }
 
 // TODO: should we expose this?
@@ -1099,9 +1099,9 @@ skb_text_position_t skb_editor_get_selection_ordered_end(const skb_editor_t* edi
 	skb_paragraph_position_t end_pos = skb_rich_text_get_paragraph_position_from_text_position(&editor->rich_text, text_range.end, SKB_AFFINITY_USE);
 
 	if (skb_is_rtl(skb__get_layout_resolved_direction(editor, end_pos.paragraph_idx)))
-		return skb_paragraph_position_less_than(end_pos, start_pos) ? text_range.end : text_range.start;
+		return skb_paragraph_position_less_or_equal(start_pos, end_pos) ? text_range.start : text_range.end;
 
-	return skb_paragraph_position_less_than(end_pos, start_pos) ? text_range.start : text_range.end;
+	return skb_paragraph_position_less_or_equal(start_pos, end_pos) ? text_range.end : text_range.start;
 }
 
 static bool skb__is_at_first_line(const skb_editor_t* editor, skb_paragraph_position_t paragraph_pos)
@@ -1722,11 +1722,11 @@ void skb_editor_process_mouse_drag(skb_editor_t* editor, float x, float y)
 		const skb_paragraph_position_t initial_start = skb_rich_text_get_paragraph_position_from_text_position(&editor->rich_text, editor->drag_initial_selection.start, SKB_AFFINITY_USE);
 		const skb_paragraph_position_t initial_end = skb_rich_text_get_paragraph_position_from_text_position(&editor->rich_text, editor->drag_initial_selection.end, SKB_AFFINITY_USE);
 
-		if (skb_paragraph_position_less_than(sel_start, initial_start)) {
+		if (!skb_paragraph_position_less_or_equal(initial_start, sel_start)) {
 			// The selection got expanded before the initial selection range start.
 			editor->selection.start = sel_start_pos;
 			editor->selection.end = editor->drag_initial_selection.end;
-		} else if (skb_paragraph_position_less_than(initial_end, sel_end)) {
+		} else if (!skb_paragraph_position_less_or_equal(sel_end, initial_end)) {
 			// The selection got expanded past the initial selection range end.
 			editor->selection.start = editor->drag_initial_selection.start;
 			editor->selection.end = sel_end_pos;

--- a/src/skb_editor.c
+++ b/src/skb_editor.c
@@ -1083,9 +1083,9 @@ skb_text_position_t skb_editor_get_selection_ordered_start(const skb_editor_t* e
 	skb_paragraph_position_t end_pos = skb_rich_text_get_paragraph_position_from_text_position(&editor->rich_text, text_range.end, SKB_AFFINITY_USE);
 
 	if (skb_is_rtl(skb__get_layout_resolved_direction(editor, end_pos.paragraph_idx)))
-		return start_pos.global_text_offset > end_pos.global_text_offset ? text_range.start : text_range.end;
+		return skb_paragraph_position_less_than(end_pos, start_pos) ? text_range.start : text_range.end;
 
-	return start_pos.global_text_offset <= end_pos.global_text_offset ? text_range.start : text_range.end;
+	return skb_paragraph_position_less_than(end_pos, start_pos) ? text_range.end : text_range.start;
 }
 
 // TODO: should we expose this?
@@ -1099,9 +1099,9 @@ skb_text_position_t skb_editor_get_selection_ordered_end(const skb_editor_t* edi
 	skb_paragraph_position_t end_pos = skb_rich_text_get_paragraph_position_from_text_position(&editor->rich_text, text_range.end, SKB_AFFINITY_USE);
 
 	if (skb_is_rtl(skb__get_layout_resolved_direction(editor, end_pos.paragraph_idx)))
-		return start_pos.global_text_offset <= end_pos.global_text_offset ? text_range.start : text_range.end;
+		return skb_paragraph_position_less_than(end_pos, start_pos) ? text_range.end : text_range.start;
 
-	return start_pos.global_text_offset > end_pos.global_text_offset ? text_range.start : text_range.end;
+	return skb_paragraph_position_less_than(end_pos, start_pos) ? text_range.start : text_range.end;
 }
 
 static bool skb__is_at_first_line(const skb_editor_t* editor, skb_paragraph_position_t paragraph_pos)
@@ -1722,11 +1722,11 @@ void skb_editor_process_mouse_drag(skb_editor_t* editor, float x, float y)
 		const skb_paragraph_position_t initial_start = skb_rich_text_get_paragraph_position_from_text_position(&editor->rich_text, editor->drag_initial_selection.start, SKB_AFFINITY_USE);
 		const skb_paragraph_position_t initial_end = skb_rich_text_get_paragraph_position_from_text_position(&editor->rich_text, editor->drag_initial_selection.end, SKB_AFFINITY_USE);
 
-		if (sel_start.global_text_offset < initial_start.global_text_offset) {
+		if (skb_paragraph_position_less_than(sel_start, initial_start)) {
 			// The selection got expanded before the initial selection range start.
 			editor->selection.start = sel_start_pos;
 			editor->selection.end = editor->drag_initial_selection.end;
-		} else if (sel_end.global_text_offset > initial_end.global_text_offset) {
+		} else if (skb_paragraph_position_less_than(initial_end, sel_end)) {
 			// The selection got expanded past the initial selection range end.
 			editor->selection.start = editor->drag_initial_selection.start;
 			editor->selection.end = sel_end_pos;

--- a/src/skb_rich_layout.c
+++ b/src/skb_rich_layout.c
@@ -470,7 +470,7 @@ void skb_rich_layout_get_text_range_bounds(const skb_rich_layout_t* rich_layout,
 
 	skb_paragraph_position_t start_pos = skb__rich_layout_get_paragraph_position_from_text_position(rich_layout, text_range.start, SKB_AFFINITY_USE);
 	skb_paragraph_position_t end_pos = skb__rich_layout_get_paragraph_position_from_text_position(rich_layout, text_range.end, SKB_AFFINITY_USE);
-	if (start_pos.global_text_offset > end_pos.global_text_offset) {
+	if (skb_paragraph_position_less_than(end_pos, start_pos)) {
 		skb_paragraph_position_t tmp = start_pos;
 		start_pos = end_pos;
 		end_pos = tmp;

--- a/src/skb_rich_layout.c
+++ b/src/skb_rich_layout.c
@@ -470,7 +470,7 @@ void skb_rich_layout_get_text_range_bounds(const skb_rich_layout_t* rich_layout,
 
 	skb_paragraph_position_t start_pos = skb__rich_layout_get_paragraph_position_from_text_position(rich_layout, text_range.start, SKB_AFFINITY_USE);
 	skb_paragraph_position_t end_pos = skb__rich_layout_get_paragraph_position_from_text_position(rich_layout, text_range.end, SKB_AFFINITY_USE);
-	if (skb_paragraph_position_less_than(end_pos, start_pos)) {
+	if (!skb_paragraph_position_less_or_equal(start_pos, end_pos)) {
 		skb_paragraph_position_t tmp = start_pos;
 		start_pos = end_pos;
 		end_pos = tmp;

--- a/src/skb_rich_text.c
+++ b/src/skb_rich_text.c
@@ -1332,12 +1332,12 @@ skb_paragraph_range_t skb_rich_text_get_paragraph_range_from_text_range(const sk
 	skb_paragraph_position_t end_pos = skb_rich_text_get_paragraph_position_from_text_position(rich_text, text_range.end, affinity_usage);
 
 	skb_paragraph_range_t result = {0};
-	if (skb_paragraph_position_less_than(end_pos, start_pos)) {
-		result.start = end_pos;
-		result.end = start_pos;
-	} else {
+	if (skb_paragraph_position_less_or_equal(start_pos, end_pos)) {
 		result.start = start_pos;
 		result.end = end_pos;
+	} else {
+		result.start = end_pos;
+		result.end = start_pos;
 	}
 	return result;
 }

--- a/src/skb_rich_text.c
+++ b/src/skb_rich_text.c
@@ -1331,8 +1331,18 @@ skb_paragraph_range_t skb_rich_text_get_paragraph_range_from_text_range(const sk
 	skb_paragraph_position_t start_pos = skb_rich_text_get_paragraph_position_from_text_position(rich_text, text_range.start, affinity_usage);
 	skb_paragraph_position_t end_pos = skb_rich_text_get_paragraph_position_from_text_position(rich_text, text_range.end, affinity_usage);
 
+	// Compare by (paragraph_idx, text_offset): two positions can tie on
+	// global_text_offset but live in different paragraphs, and downstream
+	// consumers require start.paragraph_idx <= end.paragraph_idx.
+	bool start_first;
+	if (start_pos.paragraph_idx != end_pos.paragraph_idx) {
+		start_first = start_pos.paragraph_idx < end_pos.paragraph_idx;
+	} else {
+		start_first = start_pos.text_offset <= end_pos.text_offset;
+	}
+
 	skb_paragraph_range_t result = {0};
-	if (start_pos.global_text_offset <= end_pos.global_text_offset) {
+	if (start_first) {
 		result.start = start_pos;
 		result.end = end_pos;
 	} else {

--- a/src/skb_rich_text.c
+++ b/src/skb_rich_text.c
@@ -1331,23 +1331,13 @@ skb_paragraph_range_t skb_rich_text_get_paragraph_range_from_text_range(const sk
 	skb_paragraph_position_t start_pos = skb_rich_text_get_paragraph_position_from_text_position(rich_text, text_range.start, affinity_usage);
 	skb_paragraph_position_t end_pos = skb_rich_text_get_paragraph_position_from_text_position(rich_text, text_range.end, affinity_usage);
 
-	// Compare by (paragraph_idx, text_offset): two positions can tie on
-	// global_text_offset but live in different paragraphs, and downstream
-	// consumers require start.paragraph_idx <= end.paragraph_idx.
-	bool start_first;
-	if (start_pos.paragraph_idx != end_pos.paragraph_idx) {
-		start_first = start_pos.paragraph_idx < end_pos.paragraph_idx;
-	} else {
-		start_first = start_pos.text_offset <= end_pos.text_offset;
-	}
-
 	skb_paragraph_range_t result = {0};
-	if (start_first) {
-		result.start = start_pos;
-		result.end = end_pos;
-	} else {
+	if (skb_paragraph_position_less_than(end_pos, start_pos)) {
 		result.start = end_pos;
 		result.end = start_pos;
+	} else {
+		result.start = start_pos;
+		result.end = end_pos;
 	}
 	return result;
 }

--- a/test/test_rich_text.c
+++ b/test/test_rich_text.c
@@ -94,9 +94,9 @@ static int test_rich_text_append(void)
 	return 0;
 }
 
-// Regression: two positions can share global_text_offset while residing in
-// different paragraphs. Ordering must use (paragraph_idx, text_offset), not
-// global_text_offset alone, or start.paragraph_idx > end.paragraph_idx.
+// Verifies that skb_rich_text_get_paragraph_range_from_text_range returns a
+// range with start.paragraph_idx <= end.paragraph_idx even when the two
+// endpoints tie on global_text_offset across a paragraph boundary.
 static int test_paragraph_range_ordering(void)
 {
 	skb_temp_alloc_t* temp_alloc = skb_temp_alloc_create(1024);

--- a/test/test_rich_text.c
+++ b/test/test_rich_text.c
@@ -94,10 +94,40 @@ static int test_rich_text_append(void)
 	return 0;
 }
 
+// Regression: two positions can share global_text_offset while residing in
+// different paragraphs. Ordering must use (paragraph_idx, text_offset), not
+// global_text_offset alone, or start.paragraph_idx > end.paragraph_idx.
+static int test_paragraph_range_ordering(void)
+{
+	skb_temp_alloc_t* temp_alloc = skb_temp_alloc_create(1024);
+	ENSURE(temp_alloc != NULL);
+
+	skb_rich_text_t* rich_text = skb_rich_text_create();
+	skb_rich_text_append_utf8(rich_text, temp_alloc, "\n", -1, (skb_attribute_set_t){0});
+	// Produces two paragraphs: ["\n" global=0] and ["" global=1].
+	ENSURE(skb_rich_text_get_paragraphs_count(rich_text) == 2);
+
+	// start resolves to {paragraph_idx=1, text_offset=0, global=1} (last/empty paragraph).
+	// end   resolves to {paragraph_idx=0, text_offset=1, global=1} (end of '\n' in para 0).
+	// Both global offsets are 1, so ordering by global alone inverts start/end.
+	skb_text_range_t range = {
+		.start = { .offset = 1, .affinity = SKB_AFFINITY_NONE },
+		.end   = { .offset = 0, .affinity = SKB_AFFINITY_EOL  },
+	};
+	skb_paragraph_range_t result = skb_rich_text_get_paragraph_range_from_text_range(rich_text, range, SKB_AFFINITY_USE);
+	ENSURE(result.start.paragraph_idx <= result.end.paragraph_idx);
+
+	skb_rich_text_destroy(rich_text);
+	skb_temp_alloc_destroy(temp_alloc);
+
+	return 0;
+}
+
 int rich_text_tests(void)
 {
 	RUN_SUBTEST(test_rich_text_create);
 	RUN_SUBTEST(test_rich_text_replace);
 	RUN_SUBTEST(test_rich_text_append);
+	RUN_SUBTEST(test_paragraph_range_ordering);
 	return 0;
 }

--- a/test/tester.c
+++ b/test/tester.c
@@ -16,6 +16,7 @@ int rasterizer_tests(void);
 int image_atlas_tests(void);
 int cpp_tests(void);
 int attributed_text_tests(void);
+int rich_text_tests(void);
 
 int main( void )
 {
@@ -36,6 +37,7 @@ int main( void )
 	RUN_TEST(image_atlas_tests);
 	RUN_TEST(cpp_tests);
 	RUN_TEST(attributed_text_tests);
+	RUN_TEST(rich_text_tests);
 
 	printf( "======================================\n" );
 	printf( "All tests passed!\n" );


### PR DESCRIPTION
Hey Mikko, I found this problem while doing fuzz-testing on [papaya.io](https://papaya.io/). I've used Claude Code to help detect and fix this issue. Ofc, I have also reviewed this PR myself, and verified that this fixes the issue.

Problem
-------
A text range is two positions: start and end. Internally a position has both a "paragraph index" (which paragraph it lives in) and a "global text offset" (how far into the whole document it is). For well-formed inputs these two agree: a later paragraph also has a later global offset.

`skb_rich_text_get_paragraph_range_from_text_range` orders its two positions by global offset alone, then hands the ordered pair to `skb__rich_text_replace`. But `skb__rich_text_replace` doesn't only use the global offset — it indexes paragraphs directly and assumes `start.paragraph_idx <= end.paragraph_idx`.

Two positions can tie on global offset while still sitting in different paragraphs. When that happens, the ordering-by-global step silently picks the wrong order, and `skb__rich_text_replace` runs with `start.paragraph_idx > end.paragraph_idx`. From there:

  - `removed_paragraphs_count = end.paragraph_idx + 1 - start.paragraph_idx` goes negative.
  - `new_paragraphs_count = old - removed + source` therefore grows the array instead of shrinking it.
  - The follow-up `memmove` leaves two paragraph slots holding the same `attributes` pointer.
  - The next edit or reset walks those slots and calls `free()` on that pointer twice. Boom.

How a tie shows up in practice
------------------------------
The simplest way to produce a tie is to pass a position whose text offset is negative. The position lookup clamps negative offsets to `{paragraph_idx=0, text_offset=0, global_text_offset=0}`. If the other endpoint of the range happens to also resolve to global offset 0 but in a later paragraph (for instance because the leading paragraphs are empty), the two positions tie on global offset 0 but live in paragraph 0 and paragraph N respectively, and the sort picks the later paragraph as "start".

A concrete way to hit this from the editor: press Delete in a document made up of empty paragraphs. The Delete handler builds its remove range as

```
    { start = selection.end,
      end   = skb_rich_text_get_next_grapheme_pos(selection.end) }
```

and in that document `next_grapheme_pos` returns `offset = -1` (its EOL
branch computes `paragraph->global_text_offset + text_count - 1`, and
both are zero). The negative offset, the global-only sort, and the
paragraph-index-based replace path then combine to corrupt the
paragraph array.

Fix
---
Sort the two positions by `(paragraph_idx, text_offset)` instead of by global offset. That ordering matches what every downstream consumer already assumes, so the returned range always satisfies `start.paragraph_idx <= end.paragraph_idx` and the rest of the pipeline behaves correctly.