### PR TITLE
Fix assertion when querying caret info at a line-break offset

### DIFF
--- a/src/skb_layout.c
+++ b/src/skb_layout.c
@@ -3406,29 +3406,11 @@ int32_t skb_layout_get_line_index(const skb_layout_t* layout, skb_text_position_
 {
 	assert(layout);
 
-	int32_t line_idx = SKB_INVALID_INDEX;
-	for (int32_t i = 0; i < layout->lines_count; i++) {
-		const skb_layout_line_t* line = &layout->lines[i];
-		if (pos.offset >= line->text_range.start && pos.offset < line->text_range.end) {
+	int32_t line_idx = 0; // Default to first line, this should happen if pos.offset is before first line text_range.start.
+	for (int32_t i = layout->lines_count - 1; i >= 0; i--) {
+		if (pos.offset >= layout->lines[i].text_range.start) {
 			line_idx = i;
 			break;
-		}
-	}
-	if (line_idx == SKB_INVALID_INDEX) {
-		if (pos.offset < layout->lines[0].text_range.start) {
-			line_idx = 0;
-		} else if (pos.offset >= layout->lines[layout->lines_count-1].text_range.end) {
-			line_idx = layout->lines_count-1;
-		} else {
-			// Position in a gap between consecutive lines (e.g., on a hard
-			// line-break char that ends one line but isn't included in the
-			// next). Treat it as belonging to the prior line.
-			for (int32_t i = 0; i < layout->lines_count - 1; i++) {
-				if (pos.offset >= layout->lines[i].text_range.end && pos.offset < layout->lines[i+1].text_range.start) {
-					line_idx = i;
-					break;
-				}
-			}
 		}
 	}
 

--- a/src/skb_layout.c
+++ b/src/skb_layout.c
@@ -3415,10 +3415,21 @@ int32_t skb_layout_get_line_index(const skb_layout_t* layout, skb_text_position_
 		}
 	}
 	if (line_idx == SKB_INVALID_INDEX) {
-		if (pos.offset < layout->lines[0].text_range.start)
+		if (pos.offset < layout->lines[0].text_range.start) {
 			line_idx = 0;
-		else if (pos.offset >= layout->lines[layout->lines_count-1].text_range.end)
+		} else if (pos.offset >= layout->lines[layout->lines_count-1].text_range.end) {
 			line_idx = layout->lines_count-1;
+		} else {
+			// Position in a gap between consecutive lines (e.g., on a hard
+			// line-break char that ends one line but isn't included in the
+			// next). Treat it as belonging to the prior line.
+			for (int32_t i = 0; i < layout->lines_count - 1; i++) {
+				if (pos.offset >= layout->lines[i].text_range.end && pos.offset < layout->lines[i+1].text_range.start) {
+					line_idx = i;
+					break;
+				}
+			}
+		}
 	}
 
 	return line_idx;


### PR DESCRIPTION
Like the other PR, caught using a fuzzer. Also like the other PR, used Claude Code to find and fix the issue.

Problem
-------
skb_layout_get_caret_info_at takes a text position and returns the caret geometry for it. Internally it asks skb_layout_get_line_index which line the position lives on, then forwards the line index to skb_layout_get_caret_info_at_line, which eventually calls skb_caret_iterator_make. That last function asserts
    line_idx >= 0 && line_idx < layout->lines_count.

skb_layout_get_line_index has two ways to find a line:

  1. A loop that picks the line whose half-open [text_range.start, text_range.end) contains the offset.
  2. A fallback for positions that fall outside the laid-out text: before the first line (offset < lines[0].text_range.start) or past the last (offset >= lines[last].text_range.end).

There is a third case the function doesn't handle: a position that sits in a *gap* between two consecutive lines. A hard line break typically ends one line at offset N (so line[i].text_range.end == N) and starts the next line at offset N+1 (line[i+1].text_range.start == N+1); the break character itself lives at offset N and belongs to neither half-open range. For such a position the loop finds no match, neither fallback branch fires, and the function returns SKB_INVALID_INDEX. The caller then hands -1 to
skb_caret_iterator_make and the assertion aborts the process.

How it shows up in practice
---------------------------
Any caret query whose offset lands exactly on a line-terminator between two laid-out lines hits this. From the editor side, the easiest path is arrow-down navigation that places the selection at the end of a wrapped/hard-broken line in a paragraph whose layout still has the break character occupying its own offset. skb__ensure_caret_visible (called after most edits and movements) then queries skb_editor_get_caret_info_at, which walks down into skb_layout_get_caret_info_at on that paragraph's layout and trips the assertion.

Fix
---
Extend the fallback in skb_layout_get_line_index with an explicit gap case: when the offset is past lines[i].text_range.end and before lines[i+1].text_range.start, treat it as belonging to line i. The offset is conceptually the line terminator that closes line i, so attributing it to the prior line matches how every caller subsequently uses the returned line.