### PR TITLE
Add font collection revision tracking and skb_editor_update_layout()

### DIFF
--- a/include/skb_editor.h
+++ b/include/skb_editor.h
@@ -271,6 +271,18 @@ void skb_editor_set_text_utf32(skb_editor_t* editor, skb_temp_alloc_t* temp_allo
  */
 void skb_editor_set_rich_text(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_rich_text_t* rich_text);
 
+/**
+ * Updates the layout of the edited text.
+ * The layout is kept up to date automatically when the text is changed through the editor, but it
+ * does not track changes made to the resources it was shaped against. Call this function to pick
+ * up such external changes, e.g. after adding a font to the editor's font collection. Paragraphs
+ * whose layout is already up to date are not re-shaped, so the call is cheap when nothing changed.
+ * The text, selection, composition, and undo state are not affected.
+ * @param editor editor to update.
+ * @param temp_alloc temp allocator used while layouting the text.
+ */
+void skb_editor_update_layout(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc);
+
 
 //
 // Text getters

--- a/include/skb_font_collection.h
+++ b/include/skb_font_collection.h
@@ -383,6 +383,16 @@ skb_font_t* skb_font_collection_get_font(const skb_font_collection_t* font_colle
 uint32_t skb_font_collection_get_id(const skb_font_collection_t* font_collection);
 
 /**
+ * Returns the revision of the font collection. The revision is bumped every time a font is
+ * added or removed. Together with the collection id it identifies the exact set of fonts a
+ * layout was shaped against, and is included in skb_layout_params_hash_append() so that
+ * layouts become stale when the collection changes.
+ * @param font_collection font collection to use.
+ * @return revision of the font collection.
+ */
+uint32_t skb_font_collection_get_revision(const skb_font_collection_t* font_collection);
+
+/**
  * Returns the bounding rect of the specified glyph.
  * @param font_collection font collection to use.
  * @param font_handle font to use.

--- a/src/skb_editor.c
+++ b/src/skb_editor.c
@@ -629,6 +629,13 @@ void skb_editor_set_rich_text(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc
 	skb__emit_on_selection_change(editor, SKB_EDITOR_SELECTION_RESET);
 }
 
+void skb_editor_update_layout(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc)
+{
+	assert(editor);
+
+	skb__update_layout(editor, temp_alloc, (skb_rich_text_change_t){0});
+}
+
 //
 // Text getters
 //

--- a/src/skb_font_collection.c
+++ b/src/skb_font_collection.c
@@ -319,6 +319,8 @@ static skb_font_t* skb__font_create(skb_font_collection_t* font_collection, hb_f
 		}
 	}
 
+	font_collection->revision++;
+
 	return font;
 }
 
@@ -481,6 +483,8 @@ bool skb_font_collection_remove_font(skb_font_collection_t* font_collection, skb
 		return false;
 
 	skb__font_destroy(font_collection, font);
+
+	font_collection->revision++;
 
 	return true;
 }
@@ -806,6 +810,12 @@ uint32_t skb_font_collection_get_id(const skb_font_collection_t* font_collection
 {
 	assert(font_collection);
 	return font_collection->id;
+}
+
+uint32_t skb_font_collection_get_revision(const skb_font_collection_t* font_collection)
+{
+	assert(font_collection);
+	return font_collection->revision;
 }
 
 skb_rect2_t skb_font_get_glyph_bounds(const skb_font_collection_t* font_collection, const skb_font_handle_t font_handle, uint32_t glyph_id, float font_size)

--- a/src/skb_font_collection_internal.h
+++ b/src/skb_font_collection_internal.h
@@ -14,6 +14,7 @@ typedef struct hb_set_t hb_set_t;
 
 typedef struct skb_font_collection_t {
 	uint32_t id;				// ID of the font collection.
+	uint32_t revision;			// Bumped every time a font is added or removed.
 
 	skb_font_t* fonts;			// Array of fonts in the collection.
 	int32_t fonts_count;		// Number of fonts in the collection.

--- a/src/skb_layout.c
+++ b/src/skb_layout.c
@@ -100,6 +100,7 @@ skb_content_run_t skb_content_run_make_icon(skb_icon_handle_t icon_handle, float
 uint64_t skb_layout_params_hash_append(uint64_t hash, const skb_layout_params_t* params)
 {
 	hash = skb_hash64_append_uint32(hash, params->font_collection ? skb_font_collection_get_id(params->font_collection) : 0);
+	hash = skb_hash64_append_uint32(hash, params->font_collection ? skb_font_collection_get_revision(params->font_collection) : 0);
 	hash = skb_hash64_append_uint32(hash, params->icon_collection ? skb_icon_collection_get_id(params->icon_collection) : 0);
 	hash = skb_hash64_append_uint32(hash, params->attribute_collection ? skb_attribute_collection_get_id(params->attribute_collection) : 0);
 	hash = skb_hash64_append_float(hash, params->layout_width);

--- a/test/test_editor.c
+++ b/test/test_editor.c
@@ -382,6 +382,79 @@ static int test_option_word_navigation_macos(void)
 	return 0;
 }
 
+static bool has_layout_run_with_font(const skb_editor_t* editor, skb_font_handle_t font_handle)
+{
+	for (int32_t i = 0; i < skb_editor_get_paragraph_count(editor); i++) {
+		const skb_layout_t* layout = skb_editor_get_paragraph_layout(editor, i);
+		const skb_layout_run_t* layout_runs = skb_layout_get_layout_runs(layout);
+		const int32_t layout_runs_count = skb_layout_get_layout_runs_count(layout);
+		for (int32_t j = 0; j < layout_runs_count; j++) {
+			if (layout_runs[j].font_handle == font_handle)
+				return true;
+		}
+	}
+	return false;
+}
+
+static int test_update_layout_after_font_added(void)
+{
+	skb_temp_alloc_t* temp_alloc = skb_temp_alloc_create(1024);
+	ENSURE(temp_alloc != NULL);
+
+	skb_font_collection_t* font_collection = skb_font_collection_create();
+	ENSURE(font_collection != NULL);
+	skb_font_handle_t latin_font_handle = skb_font_collection_add_font(font_collection, "data/IBMPlexSans-Regular.ttf", SKB_FONT_FAMILY_DEFAULT, NULL);
+	ENSURE(latin_font_handle);
+
+	skb_attribute_t attributes[] = {
+		skb_attribute_make_font_size(15.f),
+	};
+
+	skb_editor_params_t params = {
+	 	.font_collection = font_collection,
+		.caret_mode = SKB_CARET_MODE_SKRIBIDI,
+		.paragraph_attributes = SKB_ATTRIBUTE_SET_FROM_STATIC_ARRAY(attributes),
+	};
+
+	skb_editor_t* editor = skb_editor_create(&params);
+	ENSURE(editor != NULL);
+
+	// Latin and Arabic text, shaped while only the Latin font is in the collection.
+	const char* test_text = "abc مرحبا";
+	skb_editor_set_text_utf8(editor, temp_alloc, test_text, (int32_t)strlen(test_text));
+	ENSURE(has_layout_run_with_font(editor, latin_font_handle));
+
+	// Adding a font does not touch the existing layout; it is stale until updated.
+	skb_font_handle_t arabic_font_handle = skb_font_collection_add_font(font_collection, "data/IBMPlexSansArabic-Regular.ttf", SKB_FONT_FAMILY_DEFAULT, NULL);
+	ENSURE(arabic_font_handle);
+	ENSURE(!has_layout_run_with_font(editor, arabic_font_handle));
+
+	// Updating the layout should pick up the new font for the Arabic run.
+	skb_text_range_t selection_before = skb_editor_get_current_selection(editor);
+	skb_editor_update_layout(editor, temp_alloc);
+	ENSURE(has_layout_run_with_font(editor, arabic_font_handle));
+	ENSURE(has_layout_run_with_font(editor, latin_font_handle));
+
+	// The text and selection should be unaffected.
+	char text_buffer[64];
+	const int32_t text_len = skb_editor_get_text_utf8(editor, text_buffer, sizeof(text_buffer));
+	ENSURE(text_len == (int32_t)strlen(test_text));
+	ENSURE(memcmp(text_buffer, test_text, text_len) == 0);
+	skb_text_range_t selection_after = skb_editor_get_current_selection(editor);
+	ENSURE(selection_before.start.offset == selection_after.start.offset);
+	ENSURE(selection_before.end.offset == selection_after.end.offset);
+
+	// Updating again with no changes should keep the layout intact.
+	skb_editor_update_layout(editor, temp_alloc);
+	ENSURE(has_layout_run_with_font(editor, arabic_font_handle));
+
+	skb_editor_destroy(editor);
+	skb_font_collection_destroy(font_collection);
+	skb_temp_alloc_destroy(temp_alloc);
+
+	return 0;
+}
+
 int editor_tests(void)
 {
 	RUN_SUBTEST(test_init);
@@ -389,5 +462,6 @@ int editor_tests(void)
 	RUN_SUBTEST(test_command_document_navigation_macos);
 	RUN_SUBTEST(test_shift_command_text_selection_macos);
 	RUN_SUBTEST(test_option_word_navigation_macos);
+	RUN_SUBTEST(test_update_layout_after_font_added);
 	return 0;
 }

--- a/test/test_font_collection.c
+++ b/test/test_font_collection.c
@@ -123,6 +123,46 @@ static int test_add_font_from_data(void)
 	return 0;
 }
 
+static int test_revision(void)
+{
+	skb_font_collection_t* font_collection = skb_font_collection_create();
+	ENSURE(font_collection != NULL);
+
+	const uint32_t initial_revision = skb_font_collection_get_revision(font_collection);
+
+	const skb_layout_params_t layout_params = {
+		.font_collection = font_collection,
+	};
+	const uint64_t initial_params_hash = skb_layout_params_hash_append(skb_hash64_empty(), &layout_params);
+
+	// Adding a font should bump the revision, and with it the layout params hash.
+	skb_font_handle_t font_handle = skb_font_collection_add_font(font_collection, "data/IBMPlexSans-Regular.ttf", SKB_FONT_FAMILY_DEFAULT, NULL);
+	ENSURE(font_handle);
+	const uint32_t revision_after_add = skb_font_collection_get_revision(font_collection);
+	ENSURE(revision_after_add != initial_revision);
+	ENSURE(skb_layout_params_hash_append(skb_hash64_empty(), &layout_params) != initial_params_hash);
+
+	// A failed add should leave the revision unchanged.
+	skb_font_handle_t failed_handle = skb_font_collection_add_font_from_data(font_collection, "Missing", NULL, 0, NULL, NULL, SKB_FONT_FAMILY_DEFAULT, NULL);
+	ENSURE(failed_handle == 0);
+	ENSURE(skb_font_collection_get_revision(font_collection) == revision_after_add);
+
+	// Removing a font should bump the revision.
+	bool removed = skb_font_collection_remove_font(font_collection, font_handle);
+	ENSURE(removed);
+	const uint32_t revision_after_remove = skb_font_collection_get_revision(font_collection);
+	ENSURE(revision_after_remove != revision_after_add);
+
+	// A failed remove (stale handle) should leave the revision unchanged.
+	bool removed_again = skb_font_collection_remove_font(font_collection, font_handle);
+	ENSURE(!removed_again);
+	ENSURE(skb_font_collection_get_revision(font_collection) == revision_after_remove);
+
+	skb_font_collection_destroy(font_collection);
+
+	return 0;
+}
+
 static int test_add_font_failures(void)
 {
 	skb_font_collection_t* font_collection = skb_font_collection_create();
@@ -163,6 +203,7 @@ int font_collection_tests(void)
 	RUN_SUBTEST(test_init);
 	RUN_SUBTEST(test_add_remove);
 	RUN_SUBTEST(test_add_font_from_data);
+	RUN_SUBTEST(test_revision);
 	RUN_SUBTEST(test_add_font_failures);
 	return 0;
 }


### PR DESCRIPTION
In some applications, fonts are loaded asynchronously: text is shaped with the fonts available now, missing glyphs are reported through the fallback callback, the application fetches the fonts and adds them to the collection. Until now there was no way to make existing layouts pick up the newly added fonts:

- skb_layout_params_hash_append() identified the font collection only by its id, which is assigned once at creation. A layout shaped against an older state of the collection therefore hashed identically to an up-to-date one, so both the layout cache and the rich layout's incremental rebuild kept serving stale layouts.
- The editor relayouts only as a side effect of content mutations (set text, insert, remove, attribute changes, undo); there was no public entry point to refresh the layout without touching the text. The only workaround was to reset the content wholesale, e.g. calling skb_editor_set_rich_text() with a copy of the current text, which churns the selection, composition, and undo state.

This commit makes font collection changes observable, and gives the editor a way to act on them:

- skb_font_collection_t keeps a revision counter, bumped on every successful font add or remove, exposed via skb_font_collection_get_revision().
- skb_layout_params_hash_append() includes the revision next to the collection id, so the layout cache and skb_rich_layout's params hash naturally treat layouts shaped against an older revision as stale.
- New skb_editor_update_layout() re-runs the editor's layout update without modifying any editor state. Through the params hash it rebuilds everything when the font collection has changed, and is effectively a no-op otherwise, so it is safe to call liberally (e.g. whenever an async font fetch completes).

Tests: font_collection_tests covers the revision bumps on add/remove (including no bump on failed add/remove) and the resulting params hash change; editor_tests covers the end-to-end case of shaping Latin and Arabic text with a Latin-only collection, adding an Arabic font, and verifying that skb_editor_update_layout() reshapes the Arabic run with the new font while the text and selection stay untouched.

---

As with my recent commits, I've used Claude to help me with this change. I've thoroughly reviewed it. I believe the use-case is real, and it solves a problem in my project. As always I defer to your judgement on all matters. Happy to iterate as much as you need.