### PR TITLE
fix RTL list marker crash

### DIFF
--- a/src/skb_layout.c
+++ b/src/skb_layout.c
@@ -742,10 +742,12 @@ static float skb__calc_run_end_whitespace(const skb_layout_t* layout, skb_range_
 		for (int32_t gi = start_run->glyph_range.start; gi < start_run->glyph_range.end; gi++) {
 			const skb_glyph_t* glyph = &layout->glyphs[gi];
 			const skb_cluster_t* cluster= &layout->clusters[glyph->cluster_idx];
-			if ((layout->text_props[cluster->text_offset].flags & SKB_TEXT_PROP_WHITESPACE) || (layout->text_props[cluster->text_offset].flags & SKB_TEXT_PROP_CONTROL))
-				whitespace_width += glyph->advance_x;
-			else
-				break;
+			if (cluster->text_count > 0) {
+				if ((layout->text_props[cluster->text_offset].flags & SKB_TEXT_PROP_WHITESPACE) || (layout->text_props[cluster->text_offset].flags & SKB_TEXT_PROP_CONTROL))
+					whitespace_width += glyph->advance_x;
+				else
+					break;
+			}
 		}
 	} else {
 		// Prune space used by whitespace or control characters.


### PR DESCRIPTION
I was testing the example program when I found this strange bug where the program crashes when following these steps:

1. Change direction from LTR to RTL
2. Select all
3. Create a list item
4. Press enter

It was crashing because it was dereferencing a NULL pointer inside skb__calc_run_end_whitespace(), the RTL path was missing a null check that the LTR path already have, this adds the check for the RTL branch.


https://github.com/user-attachments/assets/1ce81e45-0a49-42b9-a398-4fc8731cf176

