### PR TITLE
Add support for building as a shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,12 @@ project(skribidi
 set(SKRIBIDI_LIBRARY_TYPE "${SKRIBIDI_LIBRARY_TYPE}" CACHE STRING
     "Library type override for Skribidi (SHARED, STATIC, OBJECT, or empty to follow BUILD_SHARED_LIBS)")
 
+if (SKRIBIDI_LIBRARY_TYPE)
+    string(COMPARE EQUAL "${SKRIBIDI_LIBRARY_TYPE}" "SHARED" SKRIBIDI_BUILD_SHARED_LIBRARY)
+else()
+    set(SKRIBIDI_BUILD_SHARED_LIBRARY ${BUILD_SHARED_LIBS})
+endif()
+
 option(ENABLE_ASAN "Enable Address Sanitizer flags" OFF)
 
 if(ENABLE_ASAN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ project(skribidi
 	LANGUAGES C CXX
 )
 
+set(SKRIBIDI_LIBRARY_TYPE "${SKRIBIDI_LIBRARY_TYPE}" CACHE STRING
+    "Library type override for Skribidi (SHARED, STATIC, OBJECT, or empty to follow BUILD_SHARED_LIBS)")
+
 option(ENABLE_ASAN "Enable Address Sanitizer flags" OFF)
 
 if(ENABLE_ASAN)
@@ -56,6 +59,8 @@ set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set(CMAKE_VERBOSE_MAKEFILE ON)
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 add_subdirectory(src)
 

--- a/include/skb_attribute_collection.h
+++ b/include/skb_attribute_collection.h
@@ -31,21 +31,21 @@ static inline int32_t skb_attribute_set_handle_get_group(skb_attribute_set_handl
  * Create new attribute collection.
  * @return create attribute collection.
  */
-skb_attribute_collection_t* skb_attribute_collection_create(void);
+SKB_API skb_attribute_collection_t* skb_attribute_collection_create(void);
 
 /**
  * Destroy attribute collection.
  * @param attribute_collection attribute collection to destroy.
  */
-void skb_attribute_collection_destroy(skb_attribute_collection_t* attribute_collection);
+SKB_API void skb_attribute_collection_destroy(skb_attribute_collection_t* attribute_collection);
 
-uint32_t skb_attribute_collection_get_id(const skb_attribute_collection_t* attribute_collection);
+SKB_API uint32_t skb_attribute_collection_get_id(const skb_attribute_collection_t* attribute_collection);
 
-skb_attribute_set_handle_t skb_attribute_collection_add_set(skb_attribute_collection_t* attribute_collection, const char* name, skb_attribute_set_t attributes);
-skb_attribute_set_handle_t skb_attribute_collection_add_set_with_group(skb_attribute_collection_t* attribute_collection, const char* name, const char* group_name, skb_attribute_set_t attributes);
-skb_attribute_set_handle_t skb_attribute_collection_find_set_by_name(const skb_attribute_collection_t* attribute_collection, const char* name);
-skb_attribute_set_t skb_attribute_collection_get_set(const skb_attribute_collection_t* attribute_collection, skb_attribute_set_handle_t handle);
-skb_attribute_set_t skb_attribute_collection_get_set_by_name(const skb_attribute_collection_t* attribute_collection, const char* name);
+SKB_API skb_attribute_set_handle_t skb_attribute_collection_add_set(skb_attribute_collection_t* attribute_collection, const char* name, skb_attribute_set_t attributes);
+SKB_API skb_attribute_set_handle_t skb_attribute_collection_add_set_with_group(skb_attribute_collection_t* attribute_collection, const char* name, const char* group_name, skb_attribute_set_t attributes);
+SKB_API skb_attribute_set_handle_t skb_attribute_collection_find_set_by_name(const skb_attribute_collection_t* attribute_collection, const char* name);
+SKB_API skb_attribute_set_t skb_attribute_collection_get_set(const skb_attribute_collection_t* attribute_collection, skb_attribute_set_handle_t handle);
+SKB_API skb_attribute_set_t skb_attribute_collection_get_set_by_name(const skb_attribute_collection_t* attribute_collection, const char* name);
 
 /** @} */
 

--- a/include/skb_attributes.h
+++ b/include/skb_attributes.h
@@ -601,119 +601,119 @@ typedef struct skb_attribute_set_t {
 #define SKB_ATTRIBUTE_SET_FROM_STATIC_ARRAY(array) SKB_LITERAL(skb_attribute_set_t) { .attributes = (array), .attributes_count = SKB_COUNTOF(array) }
 
 /** Creates attribute set that is a reference to specified set in a collection. */
-skb_attribute_set_t skb_attribute_set_make_reference(skb_attribute_set_handle_t handle);
+SKB_API skb_attribute_set_t skb_attribute_set_make_reference(skb_attribute_set_handle_t handle);
 
 /** Creates attribute set that is a reference to specified set in a collection. */
-skb_attribute_set_t skb_attribute_set_make_reference_by_name(const skb_attribute_collection_t* attribute_collection, const char* name);
+SKB_API skb_attribute_set_t skb_attribute_set_make_reference_by_name(const skb_attribute_collection_t* attribute_collection, const char* name);
 
 
 /** @returns new text base direction attribute. See skb_attribute_text_base_direction_t */
-skb_attribute_t skb_attribute_make_text_base_direction(skb_text_direction_t direction);
+SKB_API skb_attribute_t skb_attribute_make_text_base_direction(skb_text_direction_t direction);
 
 /** @returns new language attribute. See skb_attribute_lang_t */
-skb_attribute_t skb_attribute_make_lang(const char* lang);
+SKB_API skb_attribute_t skb_attribute_make_lang(const char* lang);
 
 /** @returns new font family attribute. See skb_attribute_font_t */
-skb_attribute_t skb_attribute_make_font_family(uint8_t family);
+SKB_API skb_attribute_t skb_attribute_make_font_family(uint8_t family);
 
 /** @returns new font size attribute. See skb_attribute_font_t */
-skb_attribute_t skb_attribute_make_font_size(float size);
+SKB_API skb_attribute_t skb_attribute_make_font_size(float size);
 
 /** @returns new font size scaling attribute. See skb_attribute_font_scaling_t */
-skb_attribute_t skb_attribute_make_font_size_scaling(skb_font_size_scaling_t type, float scale);
+SKB_API skb_attribute_t skb_attribute_make_font_size_scaling(skb_font_size_scaling_t type, float scale);
 
 /** @returns new font weight attribute. See skb_attribute_font_t */
-skb_attribute_t skb_attribute_make_font_weight(skb_weight_t weight);
+SKB_API skb_attribute_t skb_attribute_make_font_weight(skb_weight_t weight);
 
 /** @returns new font style attribute. See skb_attribute_font_t */
-skb_attribute_t skb_attribute_make_font_style(skb_style_t style);
+SKB_API skb_attribute_t skb_attribute_make_font_style(skb_style_t style);
 
 /** @returns new font attribute. See skb_attribute_font_t */
-skb_attribute_t skb_attribute_make_font_stretch(skb_stretch_t stretch);
+SKB_API skb_attribute_t skb_attribute_make_font_stretch(skb_stretch_t stretch);
 
 /** @returns new font feature attribute. See skb_attribute_font_feature_t */
-skb_attribute_t skb_attribute_make_font_feature(uint32_t tag, uint32_t value);
+SKB_API skb_attribute_t skb_attribute_make_font_feature(uint32_t tag, uint32_t value);
 
 /** @returns new spacing attribute. See skb_attribute_letter_spacing_t */
-skb_attribute_t skb_attribute_make_letter_spacing(float letter_spacing);
+SKB_API skb_attribute_t skb_attribute_make_letter_spacing(float letter_spacing);
 
 /** @returns new spacing attribute. See skb_attribute_word_spacing_t */
-skb_attribute_t skb_attribute_make_word_spacing(float word_spacing);
+SKB_API skb_attribute_t skb_attribute_make_word_spacing(float word_spacing);
 
 /** @returns new line height attribute. See skb_attribute_line_height_t */
-skb_attribute_t skb_attribute_make_line_height(skb_line_height_t type, float height);
+SKB_API skb_attribute_t skb_attribute_make_line_height(skb_line_height_t type, float height);
 
 /** @returns new inline padding attribute. See skb_attribute_inline_padding_t */
-skb_attribute_t skb_attribute_make_inline_padding(float start, float end, float top, float bottom);
+SKB_API skb_attribute_t skb_attribute_make_inline_padding(float start, float end, float top, float bottom);
 
 /** @returns new inline padding attribute. See skb_attribute_inline_padding_t */
-skb_attribute_t skb_attribute_make_inline_padding_hv(float horizontal, float vertical);
+SKB_API skb_attribute_t skb_attribute_make_inline_padding_hv(float horizontal, float vertical);
 
 /** @returns new tab stop increment attribute. See skb_attribute_tab_stop_increment_t */
-skb_attribute_t skb_attribute_make_tab_stop_increment(float increment);
+SKB_API skb_attribute_t skb_attribute_make_tab_stop_increment(float increment);
 
 /** @returns new paragraph padding attribute. See skb_attribute_paragraph_padding_t */
-skb_attribute_t skb_attribute_make_paragraph_padding(float start, float end, float top, float bottom);
+SKB_API skb_attribute_t skb_attribute_make_paragraph_padding(float start, float end, float top, float bottom);
 
 /** @returns new paragraph padding attribute, including group spacing. See skb_attribute_paragraph_padding_t */
-skb_attribute_t skb_attribute_make_paragraph_padding_with_spacing(float start, float end, float top, float bottom, float group_spacing);
+SKB_API skb_attribute_t skb_attribute_make_paragraph_padding_with_spacing(float start, float end, float top, float bottom, float group_spacing);
 
 /** @returns new idnent level attribute. See skb_attribute_indent_level_t */
-skb_attribute_t skb_attribute_make_indent_level(int32_t level);
+SKB_API skb_attribute_t skb_attribute_make_indent_level(int32_t level);
 
 /** @returns new indent increment attribute. See skb_attribute_indent_increment_t */
-skb_attribute_t skb_attribute_make_indent_increment(float level_increment, float first_line_increment);
+SKB_API skb_attribute_t skb_attribute_make_indent_increment(float level_increment, float first_line_increment);
 
 /** @returns new tab stop increment attribute. See skb_attribute_tab_stop_increment_t */
-skb_attribute_t skb_attribute_make_list_marker(skb_list_marker_style_t style, float indent, float spacing, uint32_t codepoint);
+SKB_API skb_attribute_t skb_attribute_make_list_marker(skb_list_marker_style_t style, float indent, float spacing, uint32_t codepoint);
 
 /** @returns new text wrap attribute. See skb_attribute_text_wrap_t */
-skb_attribute_t skb_attribute_make_text_wrap(skb_text_wrap_t text_wrap);
+SKB_API skb_attribute_t skb_attribute_make_text_wrap(skb_text_wrap_t text_wrap);
 
 /** @returns new text overflow attribute. See skb_attribute_text overflow_t */
-skb_attribute_t skb_attribute_make_text_overflow(skb_text_overflow_t text_overflow);
+SKB_API skb_attribute_t skb_attribute_make_text_overflow(skb_text_overflow_t text_overflow);
 
 /** @returns new vertical trim attribute. See skb_attribute_vertical trim_t */
-skb_attribute_t skb_attribute_make_vertical_trim(skb_vertical_trim_t vertical_trim);
+SKB_API skb_attribute_t skb_attribute_make_vertical_trim(skb_vertical_trim_t vertical_trim);
 
 /** @returns new horizontal align attribute. See skb_attribute_align_t */
-skb_attribute_t skb_attribute_make_horizontal_align(skb_align_t horizontal_align);
+SKB_API skb_attribute_t skb_attribute_make_horizontal_align(skb_align_t horizontal_align);
 
 /** @returns new vertical align attribute. See skb_attribute_align_t */
-skb_attribute_t skb_attribute_make_vertical_align(skb_align_t vertical_align);
+SKB_API skb_attribute_t skb_attribute_make_vertical_align(skb_align_t vertical_align);
 
 /** @returns new baseline align attribute. See skb_attribute_baseline_align_t */
-skb_attribute_t skb_attribute_make_baseline_align(skb_baseline_t baseline_align);
+SKB_API skb_attribute_t skb_attribute_make_baseline_align(skb_baseline_t baseline_align);
 
 /** @returns new baseline shift attribute. See skb_attribute_baseline_shift_t */
-skb_attribute_t skb_attribute_make_baseline_shift(skb_baseline_shift_t type, float shift);
+SKB_API skb_attribute_t skb_attribute_make_baseline_shift(skb_baseline_shift_t type, float shift);
 
 /** @returns new color paint attribute. See skb_attribute_paint_t */
-skb_attribute_t skb_attribute_make_paint_color(uint32_t paint_tag, uint32_t state, skb_color_t color);
+SKB_API skb_attribute_t skb_attribute_make_paint_color(uint32_t paint_tag, uint32_t state, skb_color_t color);
 
 /** @returns new custom paint attribute. See skb_attribute_paint_t */
-skb_attribute_t skb_attribute_make_paint_id(uint32_t paint_tag, uint32_t state, intptr_t paint_id);
+SKB_API skb_attribute_t skb_attribute_make_paint_id(uint32_t paint_tag, uint32_t state, intptr_t paint_id);
 
 /** @returns new text decoration attribute, decoration color is inerited from text. See skb_attribute_decoration_t */
-skb_attribute_t skb_attribute_make_decoration(skb_decoration_position_t position, skb_decoration_style_t style, float thickness, float offset, uint32_t paint_tag);
+SKB_API skb_attribute_t skb_attribute_make_decoration(skb_decoration_position_t position, skb_decoration_style_t style, float thickness, float offset, uint32_t paint_tag);
 
 /** @returns new indent decoration attribute. See skb_attribute_indent_decoration_t */
-skb_attribute_t skb_attribute_make_indent_decoration(int32_t min_level, int32_t max_level, float offset_x, float width);
+SKB_API skb_attribute_t skb_attribute_make_indent_decoration(int32_t min_level, int32_t max_level, float offset_x, float width);
 
 /** @returns new object align attribute. See skb_attribute_object_align_t */
-skb_attribute_t skb_attribute_make_object_align(float baseline_ratio, skb_object_align_reference_t align_ref, skb_baseline_t align_baseline);
+SKB_API skb_attribute_t skb_attribute_make_object_align(float baseline_ratio, skb_object_align_reference_t align_ref, skb_baseline_t align_baseline);
 
 /** @returns new group attribute. See skb_attribute_group_t */
-skb_attribute_t skb_attribute_make_group_tag(uint32_t group_tag);
+SKB_API skb_attribute_t skb_attribute_make_group_tag(uint32_t group_tag);
 
 /** @returns new reference attribute. See skb_attribute_reference_t */
-skb_attribute_t skb_attribute_make_reference(skb_attribute_set_handle_t set_handle);
+SKB_API skb_attribute_t skb_attribute_make_reference(skb_attribute_set_handle_t set_handle);
 
 /** @returns new reference attribute. See skb_attribute_reference_t */
-skb_attribute_t skb_attribute_make_reference_by_name(const skb_attribute_collection_t* attribute_collection, const char* name);
+SKB_API skb_attribute_t skb_attribute_make_reference_by_name(const skb_attribute_collection_t* attribute_collection, const char* name);
 
 /** @returns new caret padding attribute. See skb_attribute_caret_padding_t */
-skb_attribute_t skb_attribute_make_caret_padding(float horizontal, float vertical);
+SKB_API skb_attribute_t skb_attribute_make_caret_padding(float horizontal, float vertical);
 
 /**
  * Returns text direction attribute or default value if not found.
@@ -722,7 +722,7 @@ skb_attribute_t skb_attribute_make_caret_padding(float horizontal, float vertica
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-skb_text_direction_t skb_attributes_get_text_base_direction(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API skb_text_direction_t skb_attributes_get_text_base_direction(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns language attribute or default value if not found.
@@ -731,7 +731,7 @@ skb_text_direction_t skb_attributes_get_text_base_direction(const skb_attribute_
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default avalue.
  */
-const char* skb_attributes_get_lang(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API const char* skb_attributes_get_lang(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first font attribute or default value if not found.
@@ -740,7 +740,7 @@ const char* skb_attributes_get_lang(const skb_attribute_set_t attributes, const 
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-uint8_t skb_attributes_get_font_family(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API uint8_t skb_attributes_get_font_family(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first font text attribute or default value if not found.
@@ -749,7 +749,7 @@ uint8_t skb_attributes_get_font_family(const skb_attribute_set_t attributes, con
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-float skb_attributes_get_font_size(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API float skb_attributes_get_font_size(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first font size attribute or default value if not found.
@@ -758,7 +758,7 @@ float skb_attributes_get_font_size(const skb_attribute_set_t attributes, const s
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-skb_attribute_font_size_scaling_t skb_attributes_get_font_size_scaling(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API skb_attribute_font_size_scaling_t skb_attributes_get_font_size_scaling(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first font text attribute or default value if not found.
@@ -767,7 +767,7 @@ skb_attribute_font_size_scaling_t skb_attributes_get_font_size_scaling(const skb
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-skb_weight_t skb_attributes_get_font_weight(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API skb_weight_t skb_attributes_get_font_weight(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first font text attribute or default value if not found.
@@ -776,7 +776,7 @@ skb_weight_t skb_attributes_get_font_weight(const skb_attribute_set_t attributes
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-skb_style_t skb_attributes_get_font_style(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API skb_style_t skb_attributes_get_font_style(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first font text attribute or default value if not found.
@@ -785,7 +785,7 @@ skb_style_t skb_attributes_get_font_style(const skb_attribute_set_t attributes, 
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-skb_stretch_t skb_attributes_get_font_stretch(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API skb_stretch_t skb_attributes_get_font_stretch(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns letter spacing attribute or default value if not found.
@@ -794,7 +794,7 @@ skb_stretch_t skb_attributes_get_font_stretch(const skb_attribute_set_t attribut
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-float skb_attributes_get_letter_spacing(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API float skb_attributes_get_letter_spacing(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns letter spacing attribute or default value if not found.
@@ -803,7 +803,7 @@ float skb_attributes_get_letter_spacing(const skb_attribute_set_t attributes, co
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-float skb_attributes_get_word_spacing(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API float skb_attributes_get_word_spacing(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first line height attribute or default value if not found.
@@ -812,7 +812,7 @@ float skb_attributes_get_word_spacing(const skb_attribute_set_t attributes, cons
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-skb_attribute_line_height_t skb_attributes_get_line_height(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API skb_attribute_line_height_t skb_attributes_get_line_height(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first inline padding attribute or default value if not found.
@@ -821,7 +821,7 @@ skb_attribute_line_height_t skb_attributes_get_line_height(const skb_attribute_s
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-skb_attribute_inline_padding_t skb_attributes_get_inline_padding(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API skb_attribute_inline_padding_t skb_attributes_get_inline_padding(const skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first tab stop increment attribute or default value if not found.
@@ -830,7 +830,7 @@ skb_attribute_inline_padding_t skb_attributes_get_inline_padding(const skb_attri
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-float skb_attributes_get_tab_stop_increment(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API float skb_attributes_get_tab_stop_increment(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first paragraph padding attribute or default value if not found.
@@ -839,7 +839,7 @@ float skb_attributes_get_tab_stop_increment(skb_attribute_set_t attributes, cons
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-skb_attribute_paragraph_padding_t skb_attributes_get_paragraph_padding(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API skb_attribute_paragraph_padding_t skb_attributes_get_paragraph_padding(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first paragraph indent level attribute or default value if not found.
@@ -848,7 +848,7 @@ skb_attribute_paragraph_padding_t skb_attributes_get_paragraph_padding(skb_attri
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-int32_t skb_attributes_get_indent_level(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API int32_t skb_attributes_get_indent_level(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first indent increment attribute or default value if not found.
@@ -857,7 +857,7 @@ int32_t skb_attributes_get_indent_level(skb_attribute_set_t attributes, const sk
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-skb_attribute_indent_increment_t skb_attributes_get_indent_increment(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API skb_attribute_indent_increment_t skb_attributes_get_indent_increment(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first list marker attribute or default value if not found.
@@ -866,7 +866,7 @@ skb_attribute_indent_increment_t skb_attributes_get_indent_increment(skb_attribu
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-skb_attribute_list_marker_t skb_attributes_get_list_marker(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API skb_attribute_list_marker_t skb_attributes_get_list_marker(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first paint attribute based on paint tag and state, or default value if no matching color is found.
@@ -877,7 +877,7 @@ skb_attribute_list_marker_t skb_attributes_get_list_marker(skb_attribute_set_t a
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-skb_attribute_paint_t skb_attributes_get_paint(uint32_t paint_tag, uint32_t state, skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API skb_attribute_paint_t skb_attributes_get_paint(uint32_t paint_tag, uint32_t state, skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns all the paints based on tag.
@@ -888,7 +888,7 @@ skb_attribute_paint_t skb_attributes_get_paint(uint32_t paint_tag, uint32_t stat
  * @param results_cap capacity of the results array.
  * @return number of results stored in the results array.
  */
-int32_t skb_attributes_get_paints_by_tag(uint32_t paint_tag, skb_attribute_set_t attributes, const skb_attribute_collection_t* collection, const skb_attribute_paint_t** results, int32_t results_cap);
+SKB_API int32_t skb_attributes_get_paints_by_tag(uint32_t paint_tag, skb_attribute_set_t attributes, const skb_attribute_collection_t* collection, const skb_attribute_paint_t** results, int32_t results_cap);
 
 /**
  * Returns first indent decoration attribute or default value if not found.
@@ -897,7 +897,7 @@ int32_t skb_attributes_get_paints_by_tag(uint32_t paint_tag, skb_attribute_set_t
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-skb_attribute_indent_decoration_t skb_attributes_get_indent_decoration(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API skb_attribute_indent_decoration_t skb_attributes_get_indent_decoration(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first object align attribute or default value if not found.
@@ -907,7 +907,7 @@ skb_attribute_indent_decoration_t skb_attributes_get_indent_decoration(skb_attri
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-skb_attribute_object_align_t skb_attributes_get_object_align(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API skb_attribute_object_align_t skb_attributes_get_object_align(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first text wrap attribute or default value if not found.
@@ -916,7 +916,7 @@ skb_attribute_object_align_t skb_attributes_get_object_align(skb_attribute_set_t
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-skb_text_wrap_t skb_attributes_get_text_wrap(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API skb_text_wrap_t skb_attributes_get_text_wrap(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first text overflow attribute or default value if not found.
@@ -925,7 +925,7 @@ skb_text_wrap_t skb_attributes_get_text_wrap(skb_attribute_set_t attributes, con
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-skb_text_overflow_t skb_attributes_get_text_overflow(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API skb_text_overflow_t skb_attributes_get_text_overflow(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first vertical trim attribute or default value if not found.
@@ -934,7 +934,7 @@ skb_text_overflow_t skb_attributes_get_text_overflow(skb_attribute_set_t attribu
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-skb_vertical_trim_t skb_attributes_get_vertical_trim(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API skb_vertical_trim_t skb_attributes_get_vertical_trim(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first horizontal align attribute or default value if not found.
@@ -943,7 +943,7 @@ skb_vertical_trim_t skb_attributes_get_vertical_trim(skb_attribute_set_t attribu
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-skb_align_t skb_attributes_get_horizontal_align(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API skb_align_t skb_attributes_get_horizontal_align(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first vertical align attribute or default value if not found.
@@ -952,7 +952,7 @@ skb_align_t skb_attributes_get_horizontal_align(skb_attribute_set_t attributes, 
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-skb_align_t skb_attributes_get_vertical_align(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API skb_align_t skb_attributes_get_vertical_align(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first baseline align attribute or default value if not found.
@@ -961,7 +961,7 @@ skb_align_t skb_attributes_get_vertical_align(skb_attribute_set_t attributes, co
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-skb_baseline_t skb_attributes_get_baseline_align(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API skb_baseline_t skb_attributes_get_baseline_align(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns first baseline align shift or default value if not found.
@@ -970,7 +970,7 @@ skb_baseline_t skb_attributes_get_baseline_align(skb_attribute_set_t attributes,
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-skb_attribute_baseline_shift_t skb_attributes_get_baseline_shift(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API skb_attribute_baseline_shift_t skb_attributes_get_baseline_shift(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Returns caret padding or default value if not found.
@@ -979,7 +979,7 @@ skb_attribute_baseline_shift_t skb_attributes_get_baseline_shift(skb_attribute_s
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-skb_attribute_caret_padding_t skb_attributes_get_caret_padding(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API skb_attribute_caret_padding_t skb_attributes_get_caret_padding(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 
 /**
@@ -989,7 +989,7 @@ skb_attribute_caret_padding_t skb_attributes_get_caret_padding(skb_attribute_set
  * @param collection attribute collection which is used to lookup attribute references.
  * @return first found attribute or default value.
  */
-uint32_t skb_attributes_get_group(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
+SKB_API uint32_t skb_attributes_get_group(skb_attribute_set_t attributes, const skb_attribute_collection_t* collection);
 
 /**
  * Collects attributes of specified type in results array from specified attribute set.
@@ -1000,7 +1000,7 @@ uint32_t skb_attributes_get_group(skb_attribute_set_t attributes, const skb_attr
  * @param results_cap capacity of the results array.
  * @return number of results stored in the results array.
  */
-int32_t skb_attributes_get_by_kind(uint32_t kind, skb_attribute_set_t attributes, const skb_attribute_collection_t* collection, const skb_attribute_t** results, int32_t results_cap);
+SKB_API int32_t skb_attributes_get_by_kind(uint32_t kind, skb_attribute_set_t attributes, const skb_attribute_collection_t* collection, const skb_attribute_t** results, int32_t results_cap);
 
 /**
  * Returns true if the attributes match. Reference attributes are matched by group.
@@ -1008,14 +1008,14 @@ int32_t skb_attributes_get_by_kind(uint32_t kind, skb_attribute_set_t attributes
  * @param b const pointer to second attribute to test
  * @return true if attributes match.
  */
-bool skb_attributes_match(const skb_attribute_t* a, const skb_attribute_t* b);
+SKB_API bool skb_attributes_match(const skb_attribute_t* a, const skb_attribute_t* b);
 
 /**
  * Returns number of attributes in the attribute set and it's parent chain.
  * @param attributes attribute set to use
  * @return attribute count.
  */
-int32_t skb_attributes_get_copy_flat_count(const skb_attribute_set_t attributes);
+SKB_API int32_t skb_attributes_get_copy_flat_count(const skb_attribute_set_t attributes);
 
 /**
  * Copies attributes from the attribute set, and it's parent chain to flat attribute list 'dest'.
@@ -1028,7 +1028,7 @@ int32_t skb_attributes_get_copy_flat_count(const skb_attribute_set_t attributes)
  * @param dest_cap capacity of the target array.
  * @return number of attributes copied.
  */
-int32_t skb_attributes_copy_flat(const skb_attribute_set_t attributes, skb_attribute_t* dest, const int32_t dest_cap);
+SKB_API int32_t skb_attributes_copy_flat(const skb_attribute_set_t attributes, skb_attribute_t* dest, const int32_t dest_cap);
 
 
 /**
@@ -1037,7 +1037,7 @@ int32_t skb_attributes_copy_flat(const skb_attribute_set_t attributes, skb_attri
  * @param attributes attributes to hash.
  * @return combined hash.
  */
-uint64_t skb_attributes_hash_append(uint64_t hash, skb_attribute_set_t attributes);
+SKB_API uint64_t skb_attributes_hash_append(uint64_t hash, skb_attribute_set_t attributes);
 
 /** @} */
 

--- a/include/skb_canvas.h
+++ b/include/skb_canvas.h
@@ -97,21 +97,21 @@ typedef enum {
  * @param target target to draw to.
  * @return pointer to the new canvas.
  */
-skb_canvas_t* skb_canvas_create(skb_temp_alloc_t* temp_alloc, skb_image_t* target);
+SKB_API skb_canvas_t* skb_canvas_create(skb_temp_alloc_t* temp_alloc, skb_image_t* target);
 
 /**
  * Destroys canvas and frees any memory associated with it.
  * Note: the canvas is allocated using the temp allocator passed in the skb_canvas_create().
  * @param c pointer to the canvas to destroy.
  */
-void skb_canvas_destroy(skb_canvas_t* c);
+SKB_API void skb_canvas_destroy(skb_canvas_t* c);
 
 /**
  * Starts a new shape and move the pen position to 'pt'.
  * @param c canvas to draw to
  * @param pt
  */
-void skb_canvas_move_to(skb_canvas_t* c, skb_vec2_t pt);
+SKB_API void skb_canvas_move_to(skb_canvas_t* c, skb_vec2_t pt);
 
 /**
  * Draws line from the pen position to 'pt'.
@@ -119,7 +119,7 @@ void skb_canvas_move_to(skb_canvas_t* c, skb_vec2_t pt);
  * @param c canvas to draw to
  * @param pt
  */
-void skb_canvas_line_to(skb_canvas_t* c, skb_vec2_t pt);
+SKB_API void skb_canvas_line_to(skb_canvas_t* c, skb_vec2_t pt);
 
 /**
  * Draws quadratic bezier segment from the pen position, using control point 'cp' to end segment point 'pt'.
@@ -128,7 +128,7 @@ void skb_canvas_line_to(skb_canvas_t* c, skb_vec2_t pt);
  * @param cp bezier segment control point
  * @param pt end point of the bezier segment.
  */
-void skb_canvas_quad_to(skb_canvas_t* c, skb_vec2_t cp, skb_vec2_t pt);
+SKB_API void skb_canvas_quad_to(skb_canvas_t* c, skb_vec2_t cp, skb_vec2_t pt);
 
 /**
  * Draws cubi bezier segment from the pen position, using control points 'cp0' and 'cp1' to end segment point 'pt'.
@@ -138,26 +138,26 @@ void skb_canvas_quad_to(skb_canvas_t* c, skb_vec2_t cp, skb_vec2_t pt);
  * @param cp1 first control point (pt in tangent)
  * @param pt end point
  */
-void skb_canvas_cubic_to(skb_canvas_t* c, skb_vec2_t cp0, skb_vec2_t cp1, skb_vec2_t pt);
+SKB_API void skb_canvas_cubic_to(skb_canvas_t* c, skb_vec2_t cp0, skb_vec2_t cp1, skb_vec2_t pt);
 
 /**
  * Closes the shape by drawing line to the start point.
  * @param c canvas to draw to
  */
-void skb_canvas_close(skb_canvas_t* c);
+SKB_API void skb_canvas_close(skb_canvas_t* c);
 
 /**
  * Multiplies the top of the transform stack with 't' and pushes it to the top of the transform stack.
  * @param c canvas to draw to
  * @param t transform to apply.
  */
-void skb_canvas_push_transform(skb_canvas_t* c, skb_mat2_t t);
+SKB_API void skb_canvas_push_transform(skb_canvas_t* c, skb_mat2_t t);
 
 /**
  * Pops the top of the transform stack.
  * @param c canvas to draw to
  */
-void skb_canvas_pop_transform(skb_canvas_t* c);
+SKB_API void skb_canvas_pop_transform(skb_canvas_t* c);
 
 /**
  * Takes a copy of the current mask, and pushes it to the top of the mask stack.
@@ -165,26 +165,26 @@ void skb_canvas_pop_transform(skb_canvas_t* c);
  * Use skb_canvas_pop_mask() to restore to the earlier mask.
  * @param c canvas to draw to
  */
-void skb_canvas_push_mask(skb_canvas_t* c);
+SKB_API void skb_canvas_push_mask(skb_canvas_t* c);
 
 /**
  * Pops top of the mask stack and makes the earlier mask effective.
  * @param c canvas to draw to
  */
-void skb_canvas_pop_mask(skb_canvas_t* c);
+SKB_API void skb_canvas_pop_mask(skb_canvas_t* c);
 
 /**
  * Pushes new image layer and mask to the lasyer stac.
  * @param c canvas to draw to
  */
-void skb_canvas_push_layer(skb_canvas_t* c);
+SKB_API void skb_canvas_push_layer(skb_canvas_t* c);
 
 /**
  * Removes the image layer from the top of the layer stack and blends it over the previous image.
  * @param c canvas to draw to
  * @param mode the blend mode to use for compositing
  */
-void skb_canvas_pop_layer(skb_canvas_t* c, skb_blend_mode_t mode);
+SKB_API void skb_canvas_pop_layer(skb_canvas_t* c, skb_blend_mode_t mode);
 
 /**
  * Rasterizes the vector shape defined earlier into the top of the mask stack.
@@ -194,7 +194,7 @@ void skb_canvas_pop_layer(skb_canvas_t* c, skb_blend_mode_t mode);
  * This fill method is used when drawing to an Alpha image.
  * @param c canvas to draw to
  */
-void skb_canvas_fill_mask(skb_canvas_t* c);
+SKB_API void skb_canvas_fill_mask(skb_canvas_t* c);
 
 /**
  * Applies solid color using the topmost mask over the topmost image layer.
@@ -202,7 +202,7 @@ void skb_canvas_fill_mask(skb_canvas_t* c);
  * @param c canvas to draw to
  * @param color color to fill.
  */
-void skb_canvas_fill_solid_color(skb_canvas_t* c, skb_color_t color);
+SKB_API void skb_canvas_fill_solid_color(skb_canvas_t* c, skb_color_t color);
 
 /**
  * Applies linear gradient using the topmost mask over the topmost image layer.
@@ -214,7 +214,7 @@ void skb_canvas_fill_solid_color(skb_canvas_t* c, skb_color_t color);
  * @param stops color stops defining the gradient
  * @param stops_count number of gradient color stops
  */
-void skb_canvas_fill_linear_gradient(skb_canvas_t* c, skb_vec2_t p0, skb_vec2_t p1, skb_gradient_spread_t spread, const skb_color_stop_t* stops, int32_t stops_count);
+SKB_API void skb_canvas_fill_linear_gradient(skb_canvas_t* c, skb_vec2_t p0, skb_vec2_t p1, skb_gradient_spread_t spread, const skb_color_stop_t* stops, int32_t stops_count);
 
 /**
  * Applies radial gradient using the topmost mask over the topmost image layer.
@@ -229,7 +229,7 @@ void skb_canvas_fill_linear_gradient(skb_canvas_t* c, skb_vec2_t p0, skb_vec2_t 
  * @param stops color stops defining the gradient
  * @param stops_count number of gradient color stops
  */
-void skb_canvas_fill_radial_gradient(skb_canvas_t* c, skb_vec2_t p0, float r0, skb_vec2_t p1, float r1, skb_gradient_spread_t spread, const skb_color_stop_t* stops, int32_t stops_count);
+SKB_API void skb_canvas_fill_radial_gradient(skb_canvas_t* c, skb_vec2_t p0, float r0, skb_vec2_t p1, float r1, skb_gradient_spread_t spread, const skb_color_stop_t* stops, int32_t stops_count);
 
 /** @} */
 

--- a/include/skb_common.h
+++ b/include/skb_common.h
@@ -24,20 +24,14 @@ extern "C" {
 	#define SKB_LITERAL(type) (type)
 #endif
 
-#if defined(SKB_BUILD)
-	#if defined(_WIN32)
-		#define SKB_API __declspec(dllexport)
-	#elif defined(__GNUC__)
-		#define SKB_API __attribute__((visibility("default")))
-	#else
-		#define SKB_API
-	#endif
+#if defined(_WIN32) && defined(SKB_BUILD_DLL)
+	#define SKB_API __declspec(dllexport)
+#elif defined(_WIN32) && defined(SKB_DLL)
+	#define SKB_API __declspec(dllimport)
+#elif defined(__GNUC__) && defined(SKB_BUILD_DLL)
+	#define SKB_API __attribute__((visibility("default")))
 #else
-	#if defined(_WIN32)
-		#define SKB_API __declspec(dllimport)
-	#else
-		#define SKB_API
-	#endif
+	#define SKB_API
 #endif
 
 /**

--- a/include/skb_common.h
+++ b/include/skb_common.h
@@ -24,6 +24,21 @@ extern "C" {
 	#define SKB_LITERAL(type) (type)
 #endif
 
+#if defined(SKB_BUILD)
+	#if defined(_WIN32)
+		#define SKB_API __declspec(dllexport)
+	#elif defined(__GNUC__)
+		#define SKB_API __attribute__((visibility("default")))
+	#else
+		#define SKB_API
+	#endif
+#else
+	#if defined(_WIN32)
+		#define SKB_API __declspec(dllimport)
+	#else
+		#define SKB_API
+	#endif
+#endif
 
 /**
  * @defgroup common Common
@@ -251,7 +266,7 @@ static inline bool skb_paragraph_position_less_or_equal(skb_paragraph_position_t
  * @param format printf style format string.
  * @param ... parameters to format.
  */
-void skb_debug_log(const char* format, ...);
+SKB_API void skb_debug_log(const char* format, ...);
 
 /** Counts the number of items in an array. */
 #define SKB_COUNTOF(arr) (sizeof((arr)) / sizeof((arr)[0]))
@@ -288,7 +303,7 @@ enum {
  * @param size number of bytes to allocate
  * @return pointer to the allocated memory.
  */
-void* skb_malloc(size_t size);
+SKB_API void* skb_malloc(size_t size);
 
 /**
  * Allocates memory, and zeroinitializes it.
@@ -296,7 +311,7 @@ void* skb_malloc(size_t size);
  * @param size number of bytes to allocate
  * @return pointer to the allocated memory.
  */
-void* skb_malloc_zero(size_t size);
+SKB_API void* skb_malloc_zero(size_t size);
 
 /**
  * Reallocates existing memory to fit new size.
@@ -304,13 +319,13 @@ void* skb_malloc_zero(size_t size);
  * @param new_size new size
  * @return return pointer to the allocated memory
  */
-void* skb_realloc(void* ptr, size_t new_size);
+SKB_API void* skb_realloc(void* ptr, size_t new_size);
 
 /**
  * Frees previously allocated memory.
  * @param ptr pointer to the memory to free.
  */
-void skb_free(void* ptr);
+SKB_API void skb_free(void* ptr);
 
 /** Signature of destroy function */
 typedef void skb_destroy_func_t(void* context);
@@ -759,7 +774,7 @@ static inline skb_vec2_t skb_mat2_point(skb_mat2_t t, skb_vec2_t pt)
 	return res;
 }
 
-skb_mat2_t skb_mat2_inverse(skb_mat2_t t);
+SKB_API skb_mat2_t skb_mat2_inverse(skb_mat2_t t);
 
 /** 2D padding in rendering dimension. Not dependent on text direction. */
 typedef struct skb_padding2_t {
@@ -936,7 +951,7 @@ static inline bool skb_rect2i_is_empty(const skb_rect2i_t r)
  * @param container_size size of the container to align to.
  * @return
  */
-float skb_calc_align_offset(skb_align_t align, float item_size, float container_size);
+SKB_API float skb_calc_align_offset(skb_align_t align, float item_size, float container_size);
 
 /**
  * Converts start or end align to left or right depending on text direction.
@@ -944,7 +959,7 @@ float skb_calc_align_offset(skb_align_t align, float item_size, float container_
  * @param align aling type to change
  * @return changed align type.
  */
-skb_align_t skb_get_directional_align(bool is_rtl, skb_align_t align);
+SKB_API skb_align_t skb_get_directional_align(bool is_rtl, skb_align_t align);
 
 /** @} */
 
@@ -1051,26 +1066,26 @@ typedef struct skb_temp_alloc_stats_t {
  * @param default_block_size default blocks size to use, unless more memory is requested.
  * @return pointer to newly created allocator.
  */
-skb_temp_alloc_t* skb_temp_alloc_create(int32_t default_block_size);
+SKB_API skb_temp_alloc_t* skb_temp_alloc_create(int32_t default_block_size);
 
 /**
  * Frees all memory allocated by the allocator and clears the allocator.
  * @param alloc allocator to destroy
  */
-void skb_temp_alloc_destroy(skb_temp_alloc_t* alloc);
+SKB_API void skb_temp_alloc_destroy(skb_temp_alloc_t* alloc);
 
 /**
  * Reports statistics about the current allocation.
  * @param alloc allocator to report
  * @return struct containing statistics about the current state of the allocator.
  */
-skb_temp_alloc_stats_t skb_temp_alloc_stats(skb_temp_alloc_t* alloc);
+SKB_API skb_temp_alloc_stats_t skb_temp_alloc_stats(skb_temp_alloc_t* alloc);
 
 /**
  * Resets all the allocated memory blocks as free.
  * @param alloc allocator to reset
  */
-void skb_temp_alloc_reset(skb_temp_alloc_t* alloc);
+SKB_API void skb_temp_alloc_reset(skb_temp_alloc_t* alloc);
 
 /**
  * Returns a mark, which can be used to restore the allocators state later.
@@ -1079,7 +1094,7 @@ void skb_temp_alloc_reset(skb_temp_alloc_t* alloc);
  * @param alloc allocator which location to save
  * @return mark which can be used to restore the allocator to current state later
  */
-skb_temp_alloc_mark_t skb_temp_alloc_save(skb_temp_alloc_t* alloc);
+SKB_API skb_temp_alloc_mark_t skb_temp_alloc_save(skb_temp_alloc_t* alloc);
 
 /**
  * Restores the alloctors state to a previous set mark.
@@ -1087,7 +1102,7 @@ skb_temp_alloc_mark_t skb_temp_alloc_save(skb_temp_alloc_t* alloc);
  * @param alloc allocator to restore
  * @param mark state to restore
  */
-void skb_temp_alloc_restore(skb_temp_alloc_t* alloc, skb_temp_alloc_mark_t mark);
+SKB_API void skb_temp_alloc_restore(skb_temp_alloc_t* alloc, skb_temp_alloc_mark_t mark);
 
 /**
  * Allocates a requested size of memory. The returned memory is aligned to SKB_TEMPALLOC_ALIGN.
@@ -1095,7 +1110,7 @@ void skb_temp_alloc_restore(skb_temp_alloc_t* alloc, skb_temp_alloc_mark_t mark)
  * @param size size of the allocation in bytes.
  * @return pointer to the allocated memory.
  */
-void* skb_temp_alloc_alloc(skb_temp_alloc_t* alloc, int32_t size);
+SKB_API void* skb_temp_alloc_alloc(skb_temp_alloc_t* alloc, int32_t size);
 
 /**
  * Reallocates existing allocation to new size. The returned memory is aligned to SKB_TEMPALLOC_ALIGN.
@@ -1106,7 +1121,7 @@ void* skb_temp_alloc_alloc(skb_temp_alloc_t* alloc, int32_t size);
  * @param new_size new size of the allocation in bytes.
  * @return pointer to the allocated memory.
  */
-void* skb_temp_alloc_realloc(skb_temp_alloc_t* alloc, void* ptr, int32_t new_size);
+SKB_API void* skb_temp_alloc_realloc(skb_temp_alloc_t* alloc, void* ptr, int32_t new_size);
 
 /**
  * Frees allocated memory.
@@ -1115,7 +1130,7 @@ void* skb_temp_alloc_realloc(skb_temp_alloc_t* alloc, void* ptr, int32_t new_siz
  * @param alloc allocator where the memory was allocated from.
  * @param ptr pointer to the allocation.
  */
-void skb_temp_alloc_free(skb_temp_alloc_t* alloc, void* ptr);
+SKB_API void skb_temp_alloc_free(skb_temp_alloc_t* alloc, void* ptr);
 
 /**
  * Helper macro to allocate number of items of specified type.
@@ -1179,13 +1194,13 @@ typedef struct skb_hash_table_t skb_hash_table_t;
  * Creates an empty hash table. Use skb_hashtable_destroy() to destroy the hash table.
  * @return initialized empty hash table.
  */
-skb_hash_table_t* skb_hash_table_create(void);
+SKB_API skb_hash_table_t* skb_hash_table_create(void);
 
 /**
  * Cleans up hash table and frees any allocated memory.
  * @param ht hash table to clean.
  */
-void skb_hash_table_destroy(skb_hash_table_t* ht);
+SKB_API void skb_hash_table_destroy(skb_hash_table_t* ht);
 
 /**
  * Adds 'value' with key 'hash' into the hash table.
@@ -1195,7 +1210,7 @@ void skb_hash_table_destroy(skb_hash_table_t* ht);
  * @param value data to place in the cache.
  * @return true if 'hash' already exists in the table.
  */
-bool skb_hash_table_add(skb_hash_table_t* ht, uint64_t hash, int32_t value);
+SKB_API bool skb_hash_table_add(skb_hash_table_t* ht, uint64_t hash, int32_t value);
 
 /**
  * Tries to get 'data' from hash table based on hash.
@@ -1204,7 +1219,7 @@ bool skb_hash_table_add(skb_hash_table_t* ht, uint64_t hash, int32_t value);
  * @param value pointer to store the found value (can be NULL).
  * @return the true if found.
  */
-bool skb_hash_table_find(skb_hash_table_t* ht, uint64_t hash, int32_t* value);
+SKB_API bool skb_hash_table_find(skb_hash_table_t* ht, uint64_t hash, int32_t* value);
 
 /**
  * Removes item from the hash table associated with 'hash'.
@@ -1212,7 +1227,7 @@ bool skb_hash_table_find(skb_hash_table_t* ht, uint64_t hash, int32_t* value);
  * @param hash hash associated with the data to remove.
  * @return true if data was removed.
  */
-bool skb_hash_table_remove(skb_hash_table_t* ht, uint64_t hash);
+SKB_API bool skb_hash_table_remove(skb_hash_table_t* ht, uint64_t hash);
 
 /** @} */
 
@@ -1365,21 +1380,21 @@ typedef void skb_data_blob_destroy_func_t(void* data, int32_t data_size, skb_tem
  * Creates new empty data blob
  * @return pointer to new data blob
  */
-skb_data_blob_t* skb_data_blob_create(void);
+SKB_API skb_data_blob_t* skb_data_blob_create(void);
 
 /**
  * Creates new empty data blob with temp allocator
  * @param temp_alloc temp allocator to use
  * @return pointer to new data blob
  */
-skb_data_blob_t* skb_data_blob_create_temp(skb_temp_alloc_t* temp_alloc);
+SKB_API skb_data_blob_t* skb_data_blob_create_temp(skb_temp_alloc_t* temp_alloc);
 
 /**
  * Duplicates data blob
  * @param data_blob data blob to duplicate
  * @return new duplicate of the given data blob.
  */
-skb_data_blob_t* skb_data_blob_duplicate(const skb_data_blob_t* data_blob);
+SKB_API skb_data_blob_t* skb_data_blob_duplicate(const skb_data_blob_t* data_blob);
 
 /**
  * Duplicates data blob with temp allocator
@@ -1387,19 +1402,19 @@ skb_data_blob_t* skb_data_blob_duplicate(const skb_data_blob_t* data_blob);
  * @param temp_alloc temp allocator to use
  * @return new duplicate of the given data blob.
  */
-skb_data_blob_t* skb_data_blob_duplicate_temp(const skb_data_blob_t* data_blob, skb_temp_alloc_t* temp_alloc);
+SKB_API skb_data_blob_t* skb_data_blob_duplicate_temp(const skb_data_blob_t* data_blob, skb_temp_alloc_t* temp_alloc);
 
 /**
  * Destroys the data blob
  * @param data_blob data blob to destroy
  */
-void skb_data_blob_destroy(skb_data_blob_t* data_blob);
+SKB_API void skb_data_blob_destroy(skb_data_blob_t* data_blob);
 
 /**
  * Reset a data blob and destroys the contents.
  * @param data_blob data blob to reset
  */
-void skb_data_blob_reset(skb_data_blob_t* data_blob);
+SKB_API void skb_data_blob_reset(skb_data_blob_t* data_blob);
 
 /**
  * Sets data blob to a utf-8 string
@@ -1407,7 +1422,7 @@ void skb_data_blob_reset(skb_data_blob_t* data_blob);
  * @param utf8 utf-8 string to copy
  * @param utf8_count length of the utf-8 string, or -1 if null terminated.
  */
-void skb_data_blob_set_utf8(skb_data_blob_t* data_blob, const char* utf8, int32_t utf8_count);
+SKB_API void skb_data_blob_set_utf8(skb_data_blob_t* data_blob, const char* utf8, int32_t utf8_count);
 
 /**
  * Sets data blob to a utf-32 string
@@ -1415,7 +1430,7 @@ void skb_data_blob_set_utf8(skb_data_blob_t* data_blob, const char* utf8, int32_
  * @param utf32 utf-32 string to copy
  * @param utf32_count length of the utf-32 string, or -1 if null terminated.
  */
-void skb_data_blob_set_utf32(skb_data_blob_t* data_blob, const uint32_t* utf32, int32_t utf32_count);
+SKB_API void skb_data_blob_set_utf32(skb_data_blob_t* data_blob, const uint32_t* utf32, int32_t utf32_count);
 
 /**
  * Sets the data blob to custom data. The data is duplicated using the duplicate function.
@@ -1426,7 +1441,7 @@ void skb_data_blob_set_utf32(skb_data_blob_t* data_blob, const uint32_t* utf32, 
  * @param duplicate function to use to duplicate the data
  * @param destroy function to use to destroy the data
  */
-void skb_data_blob_set(skb_data_blob_t* data_blob, uint32_t type, const void* data, int32_t data_size, skb_data_blob_duplicate_func_t* duplicate, skb_data_blob_destroy_func_t* destroy);
+SKB_API void skb_data_blob_set(skb_data_blob_t* data_blob, uint32_t type, const void* data, int32_t data_size, skb_data_blob_duplicate_func_t* duplicate, skb_data_blob_destroy_func_t* destroy);
 
 /**
  * Assings the data blob a custom data. The data pointer and size are stored as is, and are later passed to the destroy function.
@@ -1437,7 +1452,7 @@ void skb_data_blob_set(skb_data_blob_t* data_blob, uint32_t type, const void* da
  * @param duplicate function to use to duplicate the data
  * @param destroy function to use to destroy the data
  */
-void skb_data_blob_assign(skb_data_blob_t* data_blob, uint32_t type, void* data, int32_t data_size, skb_data_blob_duplicate_func_t* duplicate, skb_data_blob_destroy_func_t* destroy);
+SKB_API void skb_data_blob_assign(skb_data_blob_t* data_blob, uint32_t type, void* data, int32_t data_size, skb_data_blob_duplicate_func_t* duplicate, skb_data_blob_destroy_func_t* destroy);
 
 /**
  * Returns const pointer to zero terminated utf-8 string stored in data blob.
@@ -1445,7 +1460,7 @@ void skb_data_blob_assign(skb_data_blob_t* data_blob, uint32_t type, void* data,
  * @param utf8_count (out, optional) length of the utf-8 string (zero terminator not included)
  * @return const pointer to the utf-8 string, or NULL if the data is not utf-8, or is empty
  */
-const char* skb_data_blob_get_utf8(const skb_data_blob_t* data_blob, int32_t* utf8_count);
+SKB_API const char* skb_data_blob_get_utf8(const skb_data_blob_t* data_blob, int32_t* utf8_count);
 
 /**
  * Returns const pointer to zero terminated utf-32 string stored in data blob.
@@ -1453,14 +1468,14 @@ const char* skb_data_blob_get_utf8(const skb_data_blob_t* data_blob, int32_t* ut
  * @param utf32_count (out, optional) length of the utf-32 string (zero terminator not included)
  * @return const pointer to the utf-32 string, or NULL if the data is not utf-32, or is empty
  */
-const uint32_t* skb_data_blob_get_utf32(const skb_data_blob_t* data_blob, int32_t* utf32_count);
+SKB_API const uint32_t* skb_data_blob_get_utf32(const skb_data_blob_t* data_blob, int32_t* utf32_count);
 
 /**
  * Returns the type of the data blob.
  * @param data_blob data blob to query
  * @return type tag of the data stored in the data blob
  */
-uint32_t skb_data_blob_get_type(const skb_data_blob_t* data_blob);
+SKB_API uint32_t skb_data_blob_get_type(const skb_data_blob_t* data_blob);
 
 /**
  * Returns pointer the data stored in the data blob.
@@ -1468,7 +1483,7 @@ uint32_t skb_data_blob_get_type(const skb_data_blob_t* data_blob);
  * @param data_size (out, optional) size of the data
  * @return pointer to the  blob data.
  */
-void* skb_data_blob_get_data(skb_data_blob_t* data_blob, int32_t* data_size);
+SKB_API void* skb_data_blob_get_data(skb_data_blob_t* data_blob, int32_t* data_size);
 
 /** @} */
 
@@ -1518,23 +1533,23 @@ typedef enum {
 } skb_character_t;
 
 /** @returns true of the character serve as a base for emoji modifiers (EBase). */
-bool skb_is_emoji_modifier_base(uint32_t codepoint);
+SKB_API bool skb_is_emoji_modifier_base(uint32_t codepoint);
 /** @returns true of the character has emoji presentation by default (EPres). */
-bool skb_is_emoji_presentation(uint32_t codepoint);
+SKB_API bool skb_is_emoji_presentation(uint32_t codepoint);
 /** @returns true if the character is emoji (Emoji). */
-bool skb_is_emoji(uint32_t codepoint);
+SKB_API bool skb_is_emoji(uint32_t codepoint);
 /** @returns true if the character is emoji modifier (Emod). */
-bool skb_is_emoji_modifier(uint32_t codepoint);
+SKB_API bool skb_is_emoji_modifier(uint32_t codepoint);
 /** @returns true if the character is emoji modifier (Emod). */
-bool skb_is_regional_indicator_symbol(uint32_t codepoint);
+SKB_API bool skb_is_regional_indicator_symbol(uint32_t codepoint);
 /** @returns true if the character is variation selector (VS15 or VS16). */
-bool skb_is_variation_selector(uint32_t codepoint);
+SKB_API bool skb_is_variation_selector(uint32_t codepoint);
 /** @returns true if the character is keycap. */
-bool skb_is_keycap_base(uint32_t codepoint);
+SKB_API bool skb_is_keycap_base(uint32_t codepoint);
 /** @returns true if the character is tag specifier (tag_spec). */
-bool skb_is_tag_spec_char(uint32_t codepoint);
+SKB_API bool skb_is_tag_spec_char(uint32_t codepoint);
 /** @returns true if the character is paragraph separator. */
-bool skb_is_paragraph_separator(uint32_t codepoint);
+SKB_API bool skb_is_paragraph_separator(uint32_t codepoint);
 
 /** Emoji iterator state, see skb_emoji_run_iterator_make(). */
 typedef struct skb_emoji_run_iterator_t {
@@ -1553,7 +1568,7 @@ typedef struct skb_emoji_run_iterator_t {
  * @param emoji_category_buffer buffer used internally to categorize the codepoints, length should be at least the length of the range (range.end - range.start).
  * @return initializes iterator.
  */
-skb_emoji_run_iterator_t skb_emoji_run_iterator_make(skb_range_t range, const uint32_t* text, uint8_t* emoji_category_buffer);
+SKB_API skb_emoji_run_iterator_t skb_emoji_run_iterator_make(skb_range_t range, const uint32_t* text, uint8_t* emoji_category_buffer);
 
 /**
  * Gets the next range of emojis or normal text. This function is meant to be used in a while loop to iterator over all the emoji and text ranges in the input text.
@@ -1570,7 +1585,7 @@ skb_emoji_run_iterator_t skb_emoji_run_iterator_make(skb_range_t range, const ui
  * @param range_has_emojis (out) true of the output range has emojis
  * @return true if there are more ranges to come.
  */
-bool skb_emoji_run_iterator_next(skb_emoji_run_iterator_t* iter, skb_range_t* range, bool* range_has_emojis);
+SKB_API bool skb_emoji_run_iterator_next(skb_emoji_run_iterator_t* iter, skb_range_t* range, bool* range_has_emojis);
 
 /**
  * Converts utf-8 string to utf-32 string.
@@ -1582,7 +1597,7 @@ bool skb_emoji_run_iterator_next(skb_emoji_run_iterator_t* iter, skb_range_t* ra
  * @param utf32_cap capacity of the result utf-32 string.
  * @return total number of codeunits in the utf-32 string.
  */
-int32_t skb_utf8_to_utf32(const char* utf8, int32_t utf8_len, uint32_t* utf32, int32_t utf32_cap);
+SKB_API int32_t skb_utf8_to_utf32(const char* utf8, int32_t utf8_len, uint32_t* utf32, int32_t utf32_cap);
 
 /**
  * Counts number of utf-32 codeunits in an utf-8 string.
@@ -1590,7 +1605,7 @@ int32_t skb_utf8_to_utf32(const char* utf8, int32_t utf8_len, uint32_t* utf32, i
  * @param utf8_len length of the utf-8 string.
  * @return total number of codepoints (equals to utf-32 code units) in the inputs string.
  */
-int32_t skb_utf8_to_utf32_count(const char* utf8, int32_t utf8_len);
+SKB_API int32_t skb_utf8_to_utf32_count(const char* utf8, int32_t utf8_len);
 
 /**
  * Returns an offset in the utf8 string to the specified codepoint offset.
@@ -1599,10 +1614,10 @@ int32_t skb_utf8_to_utf32_count(const char* utf8, int32_t utf8_len);
  * @param codepoint_offset offset of the codepoint to find.
  * @return returns start offset in the string to the specified codepoint.
  */
-int32_t skb_utf8_codepoint_offset(const char* utf8, int32_t utf8_len, int32_t codepoint_offset);
+SKB_API int32_t skb_utf8_codepoint_offset(const char* utf8, int32_t utf8_len, int32_t codepoint_offset);
 
 /** @return number of utf-8 code units in a codepoint. */
-int32_t skb_utf8_num_units(uint32_t cp);
+SKB_API int32_t skb_utf8_num_units(uint32_t cp);
 
 /**
  * Encodes a codepoint to utf-8 string (max 4 utf-8 code units).
@@ -1611,7 +1626,7 @@ int32_t skb_utf8_num_units(uint32_t cp);
  * @param utf8_cap capacity of the utf-8 string.
  * @return number of code units in the result string.
  */
-int32_t skb_utf8_encode(uint32_t cp, char* utf8, int32_t utf8_cap);
+SKB_API int32_t skb_utf8_encode(uint32_t cp, char* utf8, int32_t utf8_cap);
 
 /**
  * Converts utf-32 string into utf-8 string.
@@ -1623,7 +1638,7 @@ int32_t skb_utf8_encode(uint32_t cp, char* utf8, int32_t utf8_cap);
  * @param utf8_cap capacity of the result utf-8 string.
  * @return total number of codeunits in the utf-8 string.
  */
-int32_t skb_utf32_to_utf8(const uint32_t* utf32, int32_t utf32_len, char* utf8, int32_t utf8_cap);
+SKB_API int32_t skb_utf32_to_utf8(const uint32_t* utf32, int32_t utf32_len, char* utf8, int32_t utf8_cap);
 
 /**
  * Counts number of utf-8 codeunits in an utf-32 string.
@@ -1633,12 +1648,12 @@ int32_t skb_utf32_to_utf8(const uint32_t* utf32, int32_t utf32_len, char* utf8, 
  * @param utf8_cap capacity of the result utf-8 string.
  * @return total number of codeunits in the utf-8 string.
  */
-int32_t skb_utf32_to_utf8_count(const uint32_t* utf32, int32_t utf32_len);
+SKB_API int32_t skb_utf32_to_utf8_count(const uint32_t* utf32, int32_t utf32_len);
 
 /** @return number of code units in null terminated utf-32 string. */
-int32_t skb_utf32_strlen(const uint32_t* utf32);
+SKB_API int32_t skb_utf32_strlen(const uint32_t* utf32);
 
-int32_t skb_utf32_copy(const uint32_t* src, int32_t src_len, uint32_t* dst, int32_t dst_cap);
+SKB_API int32_t skb_utf32_copy(const uint32_t* src, int32_t src_len, uint32_t* dst, int32_t dst_cap);
 
 
 /** @} */
@@ -1650,7 +1665,7 @@ int32_t skb_utf32_copy(const uint32_t* src, int32_t src_len, uint32_t* dst, int3
  */
 
 /** @return performance timer time stamp. */
-int64_t skb_perf_timer_get(void);
+SKB_API int64_t skb_perf_timer_get(void);
 
 /**
  * Calculates elapsed time in micro seconds between two performance timer samples.
@@ -1658,7 +1673,7 @@ int64_t skb_perf_timer_get(void);
  * @param end  start time sample
  * @return elapsed time between samples in seconds.
  */
-int64_t skb_perf_timer_elapsed_us(int64_t start, int64_t end);
+SKB_API int64_t skb_perf_timer_elapsed_us(int64_t start, int64_t end);
 
 /** @} */
 

--- a/include/skb_editor.h
+++ b/include/skb_editor.h
@@ -202,13 +202,13 @@ typedef enum {
  * @param params parameters for the editor.
  * @return newly create editor.
  */
-skb_editor_t* skb_editor_create(const skb_editor_params_t* params);
+SKB_API skb_editor_t* skb_editor_create(const skb_editor_params_t* params);
 
 /**
  * Destroys a text editor.
  * @param editor pointer to the editor to destroy.
  */
-void skb_editor_destroy(skb_editor_t* editor);
+SKB_API void skb_editor_destroy(skb_editor_t* editor);
 
 /**
  * Sets text change callback function.
@@ -216,7 +216,7 @@ void skb_editor_destroy(skb_editor_t* editor);
  * @param on_change_func pointer to the on change callback function
  * @param context context pointer that is passed to the callback function each time it is called.
  */
-void skb_editor_set_on_text_change_callback(skb_editor_t* editor, skb_editor_on_text_change_func_t* on_change_func, void* context);
+SKB_API void skb_editor_set_on_text_change_callback(skb_editor_t* editor, skb_editor_on_text_change_func_t* on_change_func, void* context);
 
 /**
  * Sets change callback function.
@@ -224,7 +224,7 @@ void skb_editor_set_on_text_change_callback(skb_editor_t* editor, skb_editor_on_
  * @param on_change_func pointer to the on change callback function
  * @param context context pointer that is passed to the callback function each time it is called.
  */
-void skb_editor_set_on_selection_change_callback(skb_editor_t* editor, skb_editor_on_selection_change_func_t* on_change_func, void* context);
+SKB_API void skb_editor_set_on_selection_change_callback(skb_editor_t* editor, skb_editor_on_selection_change_func_t* on_change_func, void* context);
 
 /**
  * Sets input filter function.
@@ -233,17 +233,17 @@ void skb_editor_set_on_selection_change_callback(skb_editor_t* editor, skb_edito
  * @param filter_func pointer to the filter functions
  * @param context context pointer that is passed to the callback function each time it is called.
  */
-void skb_editor_set_input_filter_callback(skb_editor_t* editor, skb_editor_input_filter_func_t* filter_func, void* context);
+SKB_API void skb_editor_set_input_filter_callback(skb_editor_t* editor, skb_editor_input_filter_func_t* filter_func, void* context);
 
 /** @return the parameters used to create the editor. */
-const skb_editor_params_t* skb_editor_get_params(const skb_editor_t* editor);
+SKB_API const skb_editor_params_t* skb_editor_get_params(const skb_editor_t* editor);
 
 /**
  * Resets text editor to empty state.
  * @param editor editor to change
  * @param params new parameters, or NULL if previous paramters should be kept.
  */
-void skb_editor_reset(skb_editor_t* editor, const skb_editor_params_t* params);
+SKB_API void skb_editor_reset(skb_editor_t* editor, const skb_editor_params_t* params);
 
 /**
  * Sets the text of the editor from an utf-8 string.
@@ -252,7 +252,7 @@ void skb_editor_reset(skb_editor_t* editor, const skb_editor_params_t* params);
  * @param utf8 pointer to the utf-8 string to set.
  * @param utf8_len length of the string, or -1 if nul terminated.
  */
-void skb_editor_set_text_utf8(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, const char* utf8, int32_t utf8_len);
+SKB_API void skb_editor_set_text_utf8(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, const char* utf8, int32_t utf8_len);
 
 /**
  * Sets the text of the editor from an utf-32 string.
@@ -261,7 +261,7 @@ void skb_editor_set_text_utf8(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc
  * @param utf32 pointer to the utf-32 string to set.
  * @param utf32_len length of the string, or -1 if nul terminated.
  */
-void skb_editor_set_text_utf32(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, const uint32_t* utf32, int32_t utf32_len);
+SKB_API void skb_editor_set_text_utf32(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, const uint32_t* utf32, int32_t utf32_len);
 
 /**
  * Sets the text of the editor from an rich text.
@@ -269,7 +269,7 @@ void skb_editor_set_text_utf32(skb_editor_t* editor, skb_temp_alloc_t* temp_allo
  * @param temp_alloc temp allocator used while setting layouting the text.
  * @param rich_text pointer to the rich text to set.
  */
-void skb_editor_set_rich_text(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_rich_text_t* rich_text);
+SKB_API void skb_editor_set_rich_text(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_rich_text_t* rich_text);
 
 
 //
@@ -277,7 +277,7 @@ void skb_editor_set_rich_text(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc
 //
 
 /** @return length of the edited text as utf-8. */
-int32_t skb_editor_get_text_utf8_count(const skb_editor_t* editor);
+SKB_API int32_t skb_editor_get_text_utf8_count(const skb_editor_t* editor);
 
 /**
  * Gets the edited text as utf-8.
@@ -286,10 +286,10 @@ int32_t skb_editor_get_text_utf8_count(const skb_editor_t* editor);
  * @param utf8_cap capacity of the buffer.
  * @return total length of the string (can be larger than buf_cap).
  */
-int32_t skb_editor_get_text_utf8(const skb_editor_t* editor, char* utf8, int32_t utf8_cap);
+SKB_API int32_t skb_editor_get_text_utf8(const skb_editor_t* editor, char* utf8, int32_t utf8_cap);
 
 /** @return length of the edited text as utf-32. */
-int32_t skb_editor_get_text_utf32_count(const skb_editor_t* editor);
+SKB_API int32_t skb_editor_get_text_utf32_count(const skb_editor_t* editor);
 
 /**
  * Gets the edited text as utf-32.
@@ -298,17 +298,17 @@ int32_t skb_editor_get_text_utf32_count(const skb_editor_t* editor);
  * @param utf32_cap capacity of the buffer.
  * @return total length of the string (can be larger than buf_cap).
  */
-int32_t skb_editor_get_text_utf32(const skb_editor_t* editor, uint32_t* utf32, int32_t utf32_cap);
+SKB_API int32_t skb_editor_get_text_utf32(const skb_editor_t* editor, uint32_t* utf32, int32_t utf32_cap);
 
 /**
  * Gets const pointer to the edited rich text.
  * @param editor editor to query
  * @return const pointer to the rich text being edited.
  */
-const skb_rich_text_t* skb_editor_get_rich_text(const skb_editor_t* editor);
+SKB_API const skb_rich_text_t* skb_editor_get_rich_text(const skb_editor_t* editor);
 
 /** @return return the text length in utf-8 of specified text range. */
-int32_t skb_editor_get_text_utf8_count_in_range(const skb_editor_t* editor, skb_text_range_t text_range);
+SKB_API int32_t skb_editor_get_text_utf8_count_in_range(const skb_editor_t* editor, skb_text_range_t text_range);
 
 /**
  * Gets the text of the specified text range text as utf-8.
@@ -318,10 +318,10 @@ int32_t skb_editor_get_text_utf8_count_in_range(const skb_editor_t* editor, skb_
  * @param utf8_cap capacity of the buffer.
  * @return total length of the selected string (can be larger than buf_cap).
  */
-int32_t skb_editor_get_text_utf8_in_range(const skb_editor_t* editor, skb_text_range_t text_range, char* utf8, int32_t utf8_cap);
+SKB_API int32_t skb_editor_get_text_utf8_in_range(const skb_editor_t* editor, skb_text_range_t text_range, char* utf8, int32_t utf8_cap);
 
 /** @return return the text length in utf-32 of specified selection. */
-int32_t skb_editor_get_text_utf32_count_in_range(const skb_editor_t* editor, skb_text_range_t text_range);
+SKB_API int32_t skb_editor_get_text_utf32_count_in_range(const skb_editor_t* editor, skb_text_range_t text_range);
 
 /**
  * Gets the text of the specified text range text as utf-32.
@@ -331,7 +331,7 @@ int32_t skb_editor_get_text_utf32_count_in_range(const skb_editor_t* editor, skb
  * @param utf32_cap capacity of the buffer.
  * @return total length of the selected string (can be larger than buf_cap).
  */
-int32_t skb_editor_get_text_utf32_in_range(const skb_editor_t* editor, skb_text_range_t text_range, uint32_t* utf32, int32_t utf32_cap);
+SKB_API int32_t skb_editor_get_text_utf32_in_range(const skb_editor_t* editor, skb_text_range_t text_range, uint32_t* utf32, int32_t utf32_cap);
 
 /**
  * Gets the rich text of the specified text range.
@@ -339,7 +339,7 @@ int32_t skb_editor_get_text_utf32_in_range(const skb_editor_t* editor, skb_text_
  * @param text_range range of text to get.
  * @param rich_text rich text where to store the selected text.
  */
-void skb_editor_get_rich_text_in_range(const skb_editor_t* editor, skb_text_range_t text_range, skb_rich_text_t* rich_text);
+SKB_API void skb_editor_get_rich_text_in_range(const skb_editor_t* editor, skb_text_range_t text_range, skb_rich_text_t* rich_text);
 
 
 //
@@ -354,7 +354,7 @@ void skb_editor_get_rich_text_in_range(const skb_editor_t* editor, skb_text_rang
  * @param editor editor to query
  * @return view offset.
  */
-skb_vec2_t skb_editor_get_view_offset(const skb_editor_t* editor);
+SKB_API skb_vec2_t skb_editor_get_view_offset(const skb_editor_t* editor);
 
 /**
  * Sets the view offset of the editor.
@@ -363,55 +363,55 @@ skb_vec2_t skb_editor_get_view_offset(const skb_editor_t* editor);
  * @param editor editor to change
  * @param view_offset new view offset
  */
-void skb_editor_set_view_offset(skb_editor_t* editor, skb_vec2_t view_offset);
+SKB_API void skb_editor_set_view_offset(skb_editor_t* editor, skb_vec2_t view_offset);
 
 /** @return view bounds of the editor. */
-skb_rect2_t skb_editor_get_view_bounds(const skb_editor_t* editor);
+SKB_API skb_rect2_t skb_editor_get_view_bounds(const skb_editor_t* editor);
 
 /** @return the bounding box of the editor content layout. */
-skb_rect2_t skb_editor_get_layout_bounds(const skb_editor_t* editor);
+SKB_API skb_rect2_t skb_editor_get_layout_bounds(const skb_editor_t* editor);
 
 /** @return const pointer to the rich layout of edited text. */
-const skb_rich_layout_t* skb_editor_get_rich_layout(const skb_editor_t* editor);
+SKB_API const skb_rich_layout_t* skb_editor_get_rich_layout(const skb_editor_t* editor);
 
 /** @return number of paragraphs in the editor. */
-int32_t skb_editor_get_paragraph_count(const skb_editor_t* editor);
+SKB_API int32_t skb_editor_get_paragraph_count(const skb_editor_t* editor);
 
 /** @return const pointer to layout of specified paragraph. */
-const skb_layout_t* skb_editor_get_paragraph_layout(const skb_editor_t* editor, int32_t paragraph_idx);
+SKB_API const skb_layout_t* skb_editor_get_paragraph_layout(const skb_editor_t* editor, int32_t paragraph_idx);
 
 /** @return y-offset of the specified paragraph. */
-skb_vec2_t skb_editor_get_paragraph_offset(const skb_editor_t* editor, int32_t paragraph_idx);
+SKB_API skb_vec2_t skb_editor_get_paragraph_offset(const skb_editor_t* editor, int32_t paragraph_idx);
 
 /** @return y-advance (advance to the start of next paragraph) of the specified paragraph. */
-float skb_editor_get_paragraph_advance_y(const skb_editor_t* editor, int32_t paragraph_idx);
+SKB_API float skb_editor_get_paragraph_advance_y(const skb_editor_t* editor, int32_t paragraph_idx);
 
 /** @return const pointer to the text of the specified paragraph. */
-const skb_text_t* skb_editor_get_paragraph_text(const skb_editor_t* editor, int32_t paragraph_idx);
+SKB_API const skb_text_t* skb_editor_get_paragraph_text(const skb_editor_t* editor, int32_t paragraph_idx);
 
 /** @return text count of specified paragraph. */
-int32_t skb_editor_get_paragraph_text_count(const skb_editor_t* editor, int32_t paragraph_idx);
+SKB_API int32_t skb_editor_get_paragraph_text_count(const skb_editor_t* editor, int32_t paragraph_idx);
 
 /** @return text content count (without paragraph separator) of specified paragraph. */
-int32_t skb_editor_get_paragraph_text_content_count(const skb_editor_t* editor, int32_t paragraph_idx);
+SKB_API int32_t skb_editor_get_paragraph_text_content_count(const skb_editor_t* editor, int32_t paragraph_idx);
 
 /** @return attribute set applied to specified paragraph. */
-skb_attribute_set_t skb_editor_get_paragraph_attributes(const skb_editor_t* editor, int32_t paragraph_idx);
+SKB_API skb_attribute_set_t skb_editor_get_paragraph_attributes(const skb_editor_t* editor, int32_t paragraph_idx);
 
 /** @return global text offset of specified paragraph. */
-int32_t skb_editor_get_paragraph_global_text_offset(const skb_editor_t* editor, int32_t paragraph_idx);
+SKB_API int32_t skb_editor_get_paragraph_global_text_offset(const skb_editor_t* editor, int32_t paragraph_idx);
 
 /** @return text range of the paragraph text. */
-skb_text_range_t skb_editor_get_paragraph_text_range(const skb_editor_t* editor, int32_t paragraph_idx);
+SKB_API skb_text_range_t skb_editor_get_paragraph_text_range(const skb_editor_t* editor, int32_t paragraph_idx);
 
 /** @return text range of the paragraph text content (excluding the paragraph separator). */
-skb_text_range_t skb_editor_get_paragraph_content_range(const skb_editor_t* editor, int32_t paragraph_idx);
+SKB_API skb_text_range_t skb_editor_get_paragraph_content_range(const skb_editor_t* editor, int32_t paragraph_idx);
 
 /** @return text position of the first character of the paragraph. */
-skb_text_position_t skb_editor_get_paragraph_content_start_pos(const skb_editor_t* editor, int32_t paragraph_idx);
+SKB_API skb_text_position_t skb_editor_get_paragraph_content_start_pos(const skb_editor_t* editor, int32_t paragraph_idx);
 
 /** @return text position of the last character of the paragraph (excluding the paragraph separator).  */
-skb_text_position_t skb_editor_get_paragraph_content_end_pos(const skb_editor_t* editor, int32_t paragraph_idx);
+SKB_API skb_text_position_t skb_editor_get_paragraph_content_end_pos(const skb_editor_t* editor, int32_t paragraph_idx);
 
 
 //
@@ -419,7 +419,7 @@ skb_text_position_t skb_editor_get_paragraph_content_end_pos(const skb_editor_t*
 //
 
 /** @return text offset of specified text position. */
-int32_t skb_editor_get_text_offset_from_text_position(const skb_editor_t* editor, skb_text_position_t text_pos);
+SKB_API int32_t skb_editor_get_text_offset_from_text_position(const skb_editor_t* editor, skb_text_position_t text_pos);
 
 /**
  * Returns paragraph position based on text position.
@@ -428,7 +428,7 @@ int32_t skb_editor_get_text_offset_from_text_position(const skb_editor_t* editor
  * @param text_pos the text position to convert
  * @return paragraph position info of the specified text position.
  */
-skb_paragraph_position_t skb_editor_get_paragraph_position_from_text_position(const skb_editor_t* editor, skb_text_position_t text_pos);
+SKB_API skb_paragraph_position_t skb_editor_get_paragraph_position_from_text_position(const skb_editor_t* editor, skb_text_position_t text_pos);
 
 /**
  * Returns the range of paragraphs the text range overlaps.
@@ -436,7 +436,7 @@ skb_paragraph_position_t skb_editor_get_paragraph_position_from_text_position(co
  * @param text_range text range
  * @return range of paragraphs the text range overlaps.
  */
-skb_range_t skb_editor_get_paragraphs_range_from_text_range(const skb_editor_t* editor, skb_text_range_t text_range);
+SKB_API skb_range_t skb_editor_get_paragraphs_range_from_text_range(const skb_editor_t* editor, skb_text_range_t text_range);
 
 /**
  * Returns validated offset range of specified text range.
@@ -444,7 +444,7 @@ skb_range_t skb_editor_get_paragraphs_range_from_text_range(const skb_editor_t* 
  * @param text_range text range.
  * @return validated text range.
  */
-skb_range_t skb_editor_get_offset_range_from_text_range(const skb_editor_t* editor, skb_text_range_t text_range);
+SKB_API skb_range_t skb_editor_get_offset_range_from_text_range(const skb_editor_t* editor, skb_text_range_t text_range);
 
 /**
  * Returns number of codepoints in the text range.
@@ -452,7 +452,7 @@ skb_range_t skb_editor_get_offset_range_from_text_range(const skb_editor_t* edit
  * @param text_range text range
  * @return number of codepoints in the text range.
  */
-int32_t skb_editor_get_text_range_count(const skb_editor_t* editor, skb_text_range_t text_range);
+SKB_API int32_t skb_editor_get_text_range_count(const skb_editor_t* editor, skb_text_range_t text_range);
 
 
 //
@@ -460,26 +460,26 @@ int32_t skb_editor_get_text_range_count(const skb_editor_t* editor, skb_text_ran
 //
 
 /** @return current selection of the editor. */
-skb_text_range_t skb_editor_get_current_selection(const skb_editor_t* editor);
+SKB_API skb_text_range_t skb_editor_get_current_selection(const skb_editor_t* editor);
 
 /**
  * Sets the current selection of the editor to specific range.
  * @param editor editor to change.
  * @param text_range new selection.
  */
-void skb_editor_select(skb_editor_t* editor, skb_text_range_t text_range);
+SKB_API void skb_editor_select(skb_editor_t* editor, skb_text_range_t text_range);
 
 /**
  * Sets the current selection of the editor to all the text.
  * @param editor editor to change.
  */
-void skb_editor_select_all(skb_editor_t* editor);
+SKB_API void skb_editor_select_all(skb_editor_t* editor);
 
 /**
  * Clears the current selection of the editor.
  * @param editor editor to change.
  */
-void skb_editor_select_none(skb_editor_t* editor);
+SKB_API void skb_editor_select_none(skb_editor_t* editor);
 
 
  //
@@ -494,7 +494,7 @@ void skb_editor_select_none(skb_editor_t* editor);
  * @param mods key modifiers.
  * @param time time stamp in seconds (used to detect double and triple clicks).
  */
-void skb_editor_process_mouse_click(skb_editor_t* editor, float x, float y, uint32_t mods, double time);
+SKB_API void skb_editor_process_mouse_click(skb_editor_t* editor, float x, float y, uint32_t mods, double time);
 
 /**
  * Processes mouse drag.
@@ -502,7 +502,7 @@ void skb_editor_process_mouse_click(skb_editor_t* editor, float x, float y, uint
  * @param x mouse x location
  * @param y mouse y location
  */
-void skb_editor_process_mouse_drag(skb_editor_t* editor, float x, float y);
+SKB_API void skb_editor_process_mouse_drag(skb_editor_t* editor, float x, float y);
 
 /**
  * Processes key press.
@@ -511,16 +511,16 @@ void skb_editor_process_mouse_drag(skb_editor_t* editor, float x, float y);
  * @param key key pressed.
  * @param mods key modifiers.
  */
-void skb_editor_process_key_pressed(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_editor_key_t key, uint32_t mods);
+SKB_API void skb_editor_process_key_pressed(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_editor_key_t key, uint32_t mods);
 
 /** @return visual caret at specified text position. */
-skb_caret_info_t skb_editor_get_caret_info_at(const skb_editor_t* editor, skb_text_position_t text_pos);
+SKB_API skb_caret_info_t skb_editor_get_caret_info_at(const skb_editor_t* editor, skb_text_position_t text_pos);
 
 /** @return line number of specified text position. */
-int32_t skb_editor_get_line_index_at(const skb_editor_t* editor, skb_text_position_t text_pos);
+SKB_API int32_t skb_editor_get_line_index_at(const skb_editor_t* editor, skb_text_position_t text_pos);
 
 /** @return column number of specified text position. */
-int32_t skb_editor_get_column_index_at(const skb_editor_t* editor, skb_text_position_t text_pos);
+SKB_API int32_t skb_editor_get_column_index_at(const skb_editor_t* editor, skb_text_position_t text_pos);
 
 /**
  * Hit tests the editor, and returns text position of the nearest character.
@@ -530,7 +530,7 @@ int32_t skb_editor_get_column_index_at(const skb_editor_t* editor, skb_text_posi
  * @param hit_y hit test location y
  * @return text position under or nearest to the hit test location.
  */
-skb_text_position_t skb_editor_hit_test(const skb_editor_t* editor, skb_movement_type_t type, float hit_x, float hit_y);
+SKB_API skb_text_position_t skb_editor_hit_test(const skb_editor_t* editor, skb_movement_type_t type, float hit_x, float hit_y);
 
 /**
  * Iterates over set of rectangles that represent the specified text range.
@@ -540,7 +540,7 @@ skb_text_position_t skb_editor_hit_test(const skb_editor_t* editor, skb_movement
  * @param callback callback to call on each rectangle
  * @param context context passed to the callback.
  */
-void skb_editor_iterate_text_range_bounds(const skb_editor_t* editor, skb_text_range_t text_range, skb_text_range_bounds_func_t* callback, void* context);
+SKB_API void skb_editor_iterate_text_range_bounds(const skb_editor_t* editor, skb_text_range_t text_range, skb_text_range_bounds_func_t* callback, void* context);
 
 /**
  * Sets temporary IME composition text as utf-32. The text will be laid out at the current cursor location.
@@ -552,7 +552,7 @@ void skb_editor_iterate_text_range_bounds(const skb_editor_t* editor, skb_text_r
  * @param utf32_len length of the string, or -1 if nul terminated.
  * @param caret_position caret position whitin the text. Zero is in front of the first character, and utf32_len is after the last character.
  */
-void skb_editor_set_composition_utf32(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, const uint32_t* utf32, int32_t utf32_len, int32_t caret_position);
+SKB_API void skb_editor_set_composition_utf32(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, const uint32_t* utf32, int32_t utf32_len, int32_t caret_position);
 
 /**
  * Commits the specified string and clears composition text.
@@ -561,14 +561,14 @@ void skb_editor_set_composition_utf32(skb_editor_t* editor, skb_temp_alloc_t* te
  * @param utf32 pointer to utf-32 string to commit, if NULL previous text set with skb_editor_set_composition_utf32 will be used.
  * @param utf32_len length of the string, or -1 if nul terminated.
  */
-void skb_editor_commit_composition_utf32(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, const uint32_t* utf32, int32_t utf32_len);
+SKB_API void skb_editor_commit_composition_utf32(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, const uint32_t* utf32, int32_t utf32_len);
 
 /**
  * Clears composition text.
  * @param editor editor to update.
  * @param temp_alloc temp allocator used for updating the editor text.
  */
-void skb_editor_clear_composition(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc);
+SKB_API void skb_editor_clear_composition(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc);
 
 //
 // Text edit
@@ -581,7 +581,7 @@ void skb_editor_clear_composition(skb_editor_t* editor, skb_temp_alloc_t* temp_a
  * @param text_range range of text to replace
  * @param paragraph_attribute attribute to set on the new paragraph, empty attribute will be ignored.
  */
-void skb_editor_insert_paragraph(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, skb_attribute_t paragraph_attribute);
+SKB_API void skb_editor_insert_paragraph(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, skb_attribute_t paragraph_attribute);
 
 /**
  * Inserts codepoint replacing the text range.
@@ -590,7 +590,7 @@ void skb_editor_insert_paragraph(skb_editor_t* editor, skb_temp_alloc_t* temp_al
  * @param text_range range of text to replace
  * @param codepoint codepoint to insert.
  */
-void skb_editor_insert_codepoint(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, uint32_t codepoint);
+SKB_API void skb_editor_insert_codepoint(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, uint32_t codepoint);
 
 /**
  * Inserts utf-8 string replacing the text range.
@@ -603,7 +603,7 @@ void skb_editor_insert_codepoint(skb_editor_t* editor, skb_temp_alloc_t* temp_al
  * @param utf8 pointer to utf-32 string to insert
  * @param utf8_len length of the string, or -1 if nul terminated
  */
-void skb_editor_insert_text_utf8(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, const char* utf8, int32_t utf8_len);
+SKB_API void skb_editor_insert_text_utf8(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, const char* utf8, int32_t utf8_len);
 
 /**
  * Inserts utf-32 string replacing the text range.
@@ -616,7 +616,7 @@ void skb_editor_insert_text_utf8(skb_editor_t* editor, skb_temp_alloc_t* temp_al
  * @param utf32 pointer to utf-32 string to insert
  * @param utf32_len length of the string, or -1 if nul terminated
  */
-void skb_editor_insert_text_utf32(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, const uint32_t* utf32, int32_t utf32_len);
+SKB_API void skb_editor_insert_text_utf32(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, const uint32_t* utf32, int32_t utf32_len);
 
 /**
  * Inserts rich text replacing the text range.
@@ -626,7 +626,7 @@ void skb_editor_insert_text_utf32(skb_editor_t* editor, skb_temp_alloc_t* temp_a
  * @param text_range range of text to replace
  * @param rich_text pointer to rich text to insert
  */
-void skb_editor_insert_rich_text(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, const skb_rich_text_t* rich_text);
+SKB_API void skb_editor_insert_rich_text(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, const skb_rich_text_t* rich_text);
 
 /**
  * Removes range of text.
@@ -635,7 +635,7 @@ void skb_editor_insert_rich_text(skb_editor_t* editor, skb_temp_alloc_t* temp_al
  * @param temp_alloc temp alloc to use for text modifications and relayout.
  * @param text_range range of text to remove
  */
-void skb_editor_remove(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range);
+SKB_API void skb_editor_remove(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range);
 
 //
 // Attribute edit
@@ -651,7 +651,7 @@ void skb_editor_remove(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_t
  * @param text_range
  * @param attribute attribute to toggle.
  */
-void skb_editor_toggle_attribute(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, skb_attribute_t attribute);
+SKB_API void skb_editor_toggle_attribute(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, skb_attribute_t attribute);
 
 /**
  * Toggles attribute with payload for the current selection.
@@ -665,7 +665,7 @@ void skb_editor_toggle_attribute(skb_editor_t* editor, skb_temp_alloc_t* temp_al
  * @param span_flags span flags to apply for the attribute, see skb_attribute_span_flags_t.
  * @param payload payload to apply for the attribute.
  */
-void skb_editor_toggle_attribute_with_payload(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, skb_attribute_t attribute, uint8_t span_flags, const skb_data_blob_t* payload);
+SKB_API void skb_editor_toggle_attribute_with_payload(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, skb_attribute_t attribute, uint8_t span_flags, const skb_data_blob_t* payload);
 
 /**
  * Applies attribute for the current selection.
@@ -677,7 +677,7 @@ void skb_editor_toggle_attribute_with_payload(skb_editor_t* editor, skb_temp_all
  * @param text_range text range to apply the attribute for.
  * @param attribute attribute to apply.
  */
-void skb_editor_set_attribute(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, skb_attribute_t attribute);
+SKB_API void skb_editor_set_attribute(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, skb_attribute_t attribute);
 
 /**
  * Applies attribute with payload for the current selection.
@@ -691,7 +691,7 @@ void skb_editor_set_attribute(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc
  * @param span_flags span flags to apply for the attribute, see skb_attribute_span_flags_t.
  * @param payload payload to apply for the attribute.
  */
-void skb_editor_set_attribute_with_payload(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, skb_attribute_t attribute, uint8_t span_flags, const skb_data_blob_t* payload);
+SKB_API void skb_editor_set_attribute_with_payload(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, skb_attribute_t attribute, uint8_t span_flags, const skb_data_blob_t* payload);
 
 /**
  * Clears attribute for specified selection range.
@@ -700,7 +700,7 @@ void skb_editor_set_attribute_with_payload(skb_editor_t* editor, skb_temp_alloc_
  * @param text_range range of text to change
  * @param attribute attribute to clear.
  */
-void skb_editor_clear_attribute(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, skb_attribute_t attribute);
+SKB_API void skb_editor_clear_attribute(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, skb_attribute_t attribute);
 
 /**
  * Clears all attributes for specified selection range.
@@ -708,7 +708,7 @@ void skb_editor_clear_attribute(skb_editor_t* editor, skb_temp_alloc_t* temp_all
  * @param temp_alloc temp alloc to use for text modifications and relayout
  * @param text_range range of text to change
  */
-void skb_editor_clear_all_attributes(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range);
+SKB_API void skb_editor_clear_all_attributes(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range);
 
 /**
  * Sets attribute for paragraphs in specified selection range, overriding any attribute of same kind.
@@ -717,7 +717,7 @@ void skb_editor_clear_all_attributes(skb_editor_t* editor, skb_temp_alloc_t* tem
  * @param text_range range of text to change
  * @param attribute attribute to set.
  */
-void skb_editor_set_paragraph_attribute(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, skb_attribute_t attribute);
+SKB_API void skb_editor_set_paragraph_attribute(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, skb_attribute_t attribute);
 
 /**
  * Applies delta change to attribute for paragraphs in specified selection range.
@@ -727,7 +727,7 @@ void skb_editor_set_paragraph_attribute(skb_editor_t* editor, skb_temp_alloc_t* 
  * @param text_range range of text to change
  * @param attribute attribute delta to apply.
  */
-void skb_editor_set_paragraph_attribute_delta(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, skb_attribute_t attribute);
+SKB_API void skb_editor_set_paragraph_attribute_delta(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, skb_text_range_t text_range, skb_attribute_t attribute);
 
 /**
  * Checks if all the paragraphs overlapping the text range has the specified attribute.
@@ -736,7 +736,7 @@ void skb_editor_set_paragraph_attribute_delta(skb_editor_t* editor, skb_temp_all
  * @param attribute attribute to check
  * @return true if all paragraph in the text range has specified attribute.
  */
-bool skb_editor_has_paragraph_attribute(const skb_editor_t* editor, skb_text_range_t text_range, skb_attribute_t attribute);
+SKB_API bool skb_editor_has_paragraph_attribute(const skb_editor_t* editor, skb_text_range_t text_range, skb_attribute_t attribute);
 
 /**
  * Checks if the text range has the specified attribute.
@@ -749,7 +749,7 @@ bool skb_editor_has_paragraph_attribute(const skb_editor_t* editor, skb_text_ran
  * @param attribute attribute to check
  * @return true the whole text range contains the specified style.
  */
-bool skb_editor_has_attribute(const skb_editor_t* editor, skb_text_range_t text_range, skb_attribute_t attribute);
+SKB_API bool skb_editor_has_attribute(const skb_editor_t* editor, skb_text_range_t text_range, skb_attribute_t attribute);
 
 /**
  * Checks if the text range has the specified attribute.
@@ -762,7 +762,7 @@ bool skb_editor_has_attribute(const skb_editor_t* editor, skb_text_range_t text_
  * @param attribute attribute to check
  * @return true the whole text range contains the specified style.
  */
-bool skb_editor_has_text_attribute(const skb_editor_t* editor, skb_text_range_t text_range, skb_attribute_t attribute);
+SKB_API bool skb_editor_has_text_attribute(const skb_editor_t* editor, skb_text_range_t text_range, skb_attribute_t attribute);
 
 /**
  * Returns all unique attributes that cover the specified range.
@@ -774,7 +774,7 @@ bool skb_editor_has_text_attribute(const skb_editor_t* editor, skb_text_range_t 
  * @param attributes_cap capacity of result array.
  * @return number of attributes found in range.
  */
-int32_t skb_editor_get_attributes(const skb_editor_t* editor, skb_text_range_t text_range, uint32_t attribute_kind, skb_attribute_t* attributes, int32_t attributes_cap);
+SKB_API int32_t skb_editor_get_attributes(const skb_editor_t* editor, skb_text_range_t text_range, uint32_t attribute_kind, skb_attribute_t* attributes, int32_t attributes_cap);
 
 /**
  * Returns payload of specified attribute in given range.
@@ -784,7 +784,7 @@ int32_t skb_editor_get_attributes(const skb_editor_t* editor, skb_text_range_t t
  * @param attribute attribute to check
  * @return pointer to the found payload.
  */
-skb_data_blob_t* skb_editor_get_attribute_payload(const skb_editor_t* editor, skb_text_range_t text_range, skb_attribute_t attribute);
+SKB_API skb_data_blob_t* skb_editor_get_attribute_payload(const skb_editor_t* editor, skb_text_range_t text_range, skb_attribute_t attribute);
 
 /**
  * Returns the whole text range of specified attribute in given range.
@@ -794,13 +794,13 @@ skb_data_blob_t* skb_editor_get_attribute_payload(const skb_editor_t* editor, sk
  * @param attribute attribute to check
  * @return text range of the text, or empty range if not found.
  */
-skb_text_range_t skb_editor_get_attribute_text_range(const skb_editor_t* editor, skb_text_range_t text_range, skb_attribute_t attribute);
+SKB_API skb_text_range_t skb_editor_get_attribute_text_range(const skb_editor_t* editor, skb_text_range_t text_range, skb_attribute_t attribute);
 
 /** @return number of active attributes. Active attributes define what style is applied to the next text that is inserted. */
-int32_t skb_editor_get_active_attributes_count(const skb_editor_t* editor);
+SKB_API int32_t skb_editor_get_active_attributes_count(const skb_editor_t* editor);
 
 /** @return const pointer to active attributes. Active attributes define what style is applied to the next text that is inserted. */
-const skb_attribute_t* skb_editor_get_active_attributes(const skb_editor_t* editor);
+SKB_API const skb_attribute_t* skb_editor_get_active_attributes(const skb_editor_t* editor);
 
 
 //
@@ -812,34 +812,34 @@ const skb_attribute_t* skb_editor_get_active_attributes(const skb_editor_t* edit
  * @param editor editor to update.
  * @return transaction id.
  */
-int32_t skb_editor_undo_transaction_begin(skb_editor_t* editor);
+SKB_API int32_t skb_editor_undo_transaction_begin(skb_editor_t* editor);
 
 /**
  * Ends undo transaction. All changes done within an transaction will be undo or redo as one change.
  * @param editor editor to update.
  * @param transaction_id transaction id from matching skb_editor_undo_transaction_begin().
  */
-void skb_editor_undo_transaction_end(skb_editor_t* editor, int32_t transaction_id);
+SKB_API void skb_editor_undo_transaction_end(skb_editor_t* editor, int32_t transaction_id);
 
 /** @return True, if the last change can be undone. */
-bool skb_editor_can_undo(skb_editor_t* editor);
+SKB_API bool skb_editor_can_undo(skb_editor_t* editor);
 
 /**
  * Undo the last change.
  * @param editor editor to update.
  * @param temp_alloc temp allocator used to relayout the text.
  */
-void skb_editor_undo(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc);
+SKB_API void skb_editor_undo(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc);
 
 /** @return True, if the last undone change can be redone. */
-bool skb_editor_can_redo(skb_editor_t* editor);
+SKB_API bool skb_editor_can_redo(skb_editor_t* editor);
 
 /**
  * Redo the last undone change.
  * @param editor editor to update.
  * @param temp_alloc temp allocator used to relayout the text.
  */
-void skb_editor_redo(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc);
+SKB_API void skb_editor_redo(skb_editor_t* editor, skb_temp_alloc_t* temp_alloc);
 
 
 /** @} */

--- a/include/skb_editor_rules.h
+++ b/include/skb_editor_rules.h
@@ -94,13 +94,13 @@ typedef struct skb_editor_rule_t {
  * Creates new empty editor rule set. Use skb_editor_rule_set_destroy() to destroy.
  * @return pointer to the newly created rule set.
  */
-skb_editor_rule_set_t* skb_editor_rule_set_create(void);
+SKB_API skb_editor_rule_set_t* skb_editor_rule_set_create(void);
 
 /**
  * Cleans up and frees an editor rule set.
  * @param rule_set ruleset to destroy.
  */
-void skb_editor_rule_set_destroy(skb_editor_rule_set_t* rule_set);
+SKB_API void skb_editor_rule_set_destroy(skb_editor_rule_set_t* rule_set);
 
 /**
  * Appends editor rules to the rule set.
@@ -108,7 +108,7 @@ void skb_editor_rule_set_destroy(skb_editor_rule_set_t* rule_set);
  * @param rules pointer to array of rules to append.
  * @param rules_count number of rules in the rules array.
  */
-void skb_editor_rule_set_append(skb_editor_rule_set_t* rule_set, const skb_editor_rule_t* rules, int32_t rules_count);
+SKB_API void skb_editor_rule_set_append(skb_editor_rule_set_t* rule_set, const skb_editor_rule_t* rules, int32_t rules_count);
 
 /**
  * Processed the rules in the rule set.
@@ -121,7 +121,7 @@ void skb_editor_rule_set_append(skb_editor_rule_set_t* rule_set, const skb_edito
  * @param context user context pointer passed to the apply callbacks.
  * @return true of a rule was succesfully processed.
  */
-bool skb_editor_rule_set_process(const skb_editor_rule_set_t* rule_set, skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, int32_t key, uint32_t key_mods, void* context);
+SKB_API bool skb_editor_rule_set_process(const skb_editor_rule_set_t* rule_set, skb_editor_t* editor, skb_temp_alloc_t* temp_alloc, int32_t key, uint32_t key_mods, void* context);
 
 
 /**
@@ -131,7 +131,7 @@ bool skb_editor_rule_set_process(const skb_editor_rule_set_t* rule_set, skb_edit
  * @param codepoint codepoint to insert.
  * @return initialized rule.
  */
-skb_editor_rule_t skb_editor_rule_make_insert_codepoint(int32_t key, uint32_t key_mods, uint32_t codepoint);
+SKB_API skb_editor_rule_t skb_editor_rule_make_insert_codepoint(int32_t key, uint32_t key_mods, uint32_t codepoint);
 
 /**
  * Makes rule to process specific key on key press with modifiers
@@ -140,7 +140,7 @@ skb_editor_rule_t skb_editor_rule_make_insert_codepoint(int32_t key, uint32_t ke
  * @param edit_key editor key to process (see skb_editor_key_t).
  * @return initialized rule.
  */
-skb_editor_rule_t skb_editor_rule_make_process_key(int32_t key, uint32_t key_mods, int32_t edit_key);
+SKB_API skb_editor_rule_t skb_editor_rule_make_process_key(int32_t key, uint32_t key_mods, int32_t edit_key);
 
 /**
  * Makes rule to process specific key on keypress.
@@ -149,7 +149,7 @@ skb_editor_rule_t skb_editor_rule_make_process_key(int32_t key, uint32_t key_mod
  * @param edit_key editor key to process (see skb_editor_key_t).
  * @return initialized rule.
  */
-skb_editor_rule_t skb_editor_rule_make_process_key_pass_mod(int32_t key, int32_t edit_key);
+SKB_API skb_editor_rule_t skb_editor_rule_make_process_key_pass_mod(int32_t key, int32_t edit_key);
 
 /**
  * Makes rule that matches specific prefix at paragraph start, and if match is found the prefix is removed and paragraph style is changed.
@@ -161,7 +161,7 @@ skb_editor_rule_t skb_editor_rule_make_process_key_pass_mod(int32_t key, int32_t
  * @param applied_attribute_name paragraph style to apply.
  * @return initialized rule.
  */
-skb_editor_rule_t skb_editor_rule_make_convert_start_prefix_to_paragraph_style(int32_t key, uint32_t key_mods, const char* prefix_utf8, const char* on_attribute_name, const char* applied_attribute_name);
+SKB_API skb_editor_rule_t skb_editor_rule_make_convert_start_prefix_to_paragraph_style(int32_t key, uint32_t key_mods, const char* prefix_utf8, const char* on_attribute_name, const char* applied_attribute_name);
 
 /**
  * Makes rule to change the indent level of all selected paragraphs.
@@ -171,7 +171,7 @@ skb_editor_rule_t skb_editor_rule_make_convert_start_prefix_to_paragraph_style(i
  * @param delta indent delta to apply for the paragraphs
  * @return initialized rule.
  */
-skb_editor_rule_t skb_editor_rule_make_change_indent(int32_t key, uint32_t key_mods, const char* on_attribute_name, int32_t delta);
+SKB_API skb_editor_rule_t skb_editor_rule_make_change_indent(int32_t key, uint32_t key_mods, const char* on_attribute_name, int32_t delta);
 
 /**
  * Makes rule to change the indent level when the caret is at the start of a paragraph.
@@ -181,7 +181,7 @@ skb_editor_rule_t skb_editor_rule_make_change_indent(int32_t key, uint32_t key_m
  * @param delta indent delta to apply for the paragraphs
  * @return initialized rule.
  */
-skb_editor_rule_t skb_editor_rule_make_change_indent_at_paragraph_start(int32_t key, uint32_t key_mods, const char* on_attribute_name, int32_t delta);
+SKB_API skb_editor_rule_t skb_editor_rule_make_change_indent_at_paragraph_start(int32_t key, uint32_t key_mods, const char* on_attribute_name, int32_t delta);
 
 /**
  * Makes rule to remove one indent level when the caret is at the start of a paragraph.
@@ -192,7 +192,7 @@ skb_editor_rule_t skb_editor_rule_make_change_indent_at_paragraph_start(int32_t 
  * @param applied_attribute_name paragraph style to apply if the indent level is 0.
  * @return initialized rule.
  */
-skb_editor_rule_t skb_editor_rule_make_remove_indent_at_paragraph_start(int32_t key, uint32_t key_mods, const char* on_attribute_name, const char* applied_attribute_name);
+SKB_API skb_editor_rule_t skb_editor_rule_make_remove_indent_at_paragraph_start(int32_t key, uint32_t key_mods, const char* on_attribute_name, const char* applied_attribute_name);
 
 /**
  * Makes rule to add a new paragraph when key is pressed on an empty paragraph.
@@ -203,7 +203,7 @@ skb_editor_rule_t skb_editor_rule_make_remove_indent_at_paragraph_start(int32_t 
  * @param applied_attribute_name paragraph style to apply to the next new paragraph.
  * @return initialized rule.
  */
-skb_editor_rule_t skb_editor_rule_make_change_style_on_empty_paragraph(int32_t key, uint32_t key_mods, const char* on_attribute_name, const char* applied_attribute_name);
+SKB_API skb_editor_rule_t skb_editor_rule_make_change_style_on_empty_paragraph(int32_t key, uint32_t key_mods, const char* on_attribute_name, const char* applied_attribute_name);
 
 /**
  * Makes rule to add a new paragraph when key is pressed at the end of a paragraph.
@@ -214,7 +214,7 @@ skb_editor_rule_t skb_editor_rule_make_change_style_on_empty_paragraph(int32_t k
  * @param applied_attribute_name paragraph style to apply to the next new paragraph.
  * @return initialized rule.
  */
-skb_editor_rule_t skb_editor_rule_make_change_style_at_paragraph_end(int32_t key, uint32_t key_mods, const char* on_attribute_name, const char* applied_attribute_name);
+SKB_API skb_editor_rule_t skb_editor_rule_make_change_style_at_paragraph_end(int32_t key, uint32_t key_mods, const char* on_attribute_name, const char* applied_attribute_name);
 
 /**
  * Makes rule to use tabs to indent the selected paragraphs.
@@ -225,7 +225,7 @@ skb_editor_rule_t skb_editor_rule_make_change_style_at_paragraph_end(int32_t key
  * @param delta indent delta.
  * @return initialized rule.
  */
-skb_editor_rule_t skb_editor_rule_make_code_change_indent(int32_t key, uint32_t key_mods, const char* on_attribute_name, int32_t delta);
+SKB_API skb_editor_rule_t skb_editor_rule_make_code_change_indent(int32_t key, uint32_t key_mods, const char* on_attribute_name, int32_t delta);
 
 /**
  * Makes rule to add a new paragraph when key is pressed on an empty paragraph.
@@ -237,7 +237,7 @@ skb_editor_rule_t skb_editor_rule_make_code_change_indent(int32_t key, uint32_t 
  * @param applied_attribute_name paragraph style to apply to the next new paragraph.
  * @return initialized rule.
  */
-skb_editor_rule_t skb_editor_rule_make_code_change_style_on_empty_paragraph(int32_t key, uint32_t key_mods, const char* on_attribute_name, const char* applied_attribute_name);
+SKB_API skb_editor_rule_t skb_editor_rule_make_code_change_style_on_empty_paragraph(int32_t key, uint32_t key_mods, const char* on_attribute_name, const char* applied_attribute_name);
 
 /**
  * Makes rule to add a new paragraph and match the tabs and the start of the new paragraph with current paragraph.
@@ -246,7 +246,7 @@ skb_editor_rule_t skb_editor_rule_make_code_change_style_on_empty_paragraph(int3
  * @param on_attribute_name expected attribute on the paragraph under the caret.
  * @return initialized rule.
  */
-skb_editor_rule_t skb_editor_rule_make_code_match_tabs(int32_t key, uint32_t key_mods, const char* on_attribute_name);
+SKB_API skb_editor_rule_t skb_editor_rule_make_code_match_tabs(int32_t key, uint32_t key_mods, const char* on_attribute_name);
 
 /**
  * Makes rule to set paragraph attribute.
@@ -255,7 +255,7 @@ skb_editor_rule_t skb_editor_rule_make_code_match_tabs(int32_t key, uint32_t key
  * @param attribute_name paragraph style to apply.
  * @return initialized rule.
  */
-skb_editor_rule_t skb_editor_rule_make_set_paragraph_attribute(int32_t key, uint32_t key_mods, const char* attribute_name);
+SKB_API skb_editor_rule_t skb_editor_rule_make_set_paragraph_attribute(int32_t key, uint32_t key_mods, const char* attribute_name);
 
 /**
  * Makes tule to toggle text attributes.
@@ -264,7 +264,7 @@ skb_editor_rule_t skb_editor_rule_make_set_paragraph_attribute(int32_t key, uint
  * @param attribute_name text attribute to toggle.
  * @return initialized rule.
  */
-skb_editor_rule_t skb_editor_rule_make_toggle_attribute(int32_t key, uint32_t key_mods, const char* attribute_name);
+SKB_API skb_editor_rule_t skb_editor_rule_make_toggle_attribute(int32_t key, uint32_t key_mods, const char* attribute_name);
 
 /** Enum describing options for skb_editor_rule_make_undo_redo. */
 typedef enum {
@@ -281,7 +281,7 @@ typedef enum {
  * @param type undo or redo, see skb_editor_rule_undo_redo_type_t.
  * @return initialized rule.
  */
-skb_editor_rule_t skb_editor_rule_make_undo_redo(int32_t key, uint32_t key_mods, skb_editor_rule_undo_redo_type_t type);
+SKB_API skb_editor_rule_t skb_editor_rule_make_undo_redo(int32_t key, uint32_t key_mods, skb_editor_rule_undo_redo_type_t type);
 
 /** Enum describing options for skb_editor_rule_make_select. */
 typedef enum {
@@ -298,7 +298,7 @@ typedef enum {
  * @param type none or all, see skb_editor_rule_select_type_t.
  * @return
  */
-skb_editor_rule_t skb_editor_rule_make_select(int32_t key, uint32_t key_mods, skb_editor_rule_select_type_t type);
+SKB_API skb_editor_rule_t skb_editor_rule_make_select(int32_t key, uint32_t key_mods, skb_editor_rule_select_type_t type);
 
 /** @} */
 

--- a/include/skb_font_collection.h
+++ b/include/skb_font_collection.h
@@ -260,14 +260,14 @@ typedef bool skb_font_fallback_func_t(skb_font_collection_t* font_collection, co
  * Creates a new font collection.
  * @return created font collection.
  */
-skb_font_collection_t* skb_font_collection_create(void);
+SKB_API skb_font_collection_t* skb_font_collection_create(void);
 
 /**
  * Destroys font collection.
  * Note: layouts store pointers to the font collection. The font collection should be destroyed only after all layouts are destroyed.
  * @param font_collection font collection to destroy.
  */
-void skb_font_collection_destroy(skb_font_collection_t* font_collection);
+SKB_API void skb_font_collection_destroy(skb_font_collection_t* font_collection);
 
 /**
  * Sets callback function that is called when we cannot match font. The callback allows the user to either collect missing fonts, or to load them.
@@ -275,7 +275,7 @@ void skb_font_collection_destroy(skb_font_collection_t* font_collection);
  * @param fallback_func function to call when font selection fails.
  * @param context Pointer passed to the callback function.
  */
-void skb_font_collection_set_on_font_fallback(skb_font_collection_t* font_collection, skb_font_fallback_func_t* fallback_func, void* context);
+SKB_API void skb_font_collection_set_on_font_fallback(skb_font_collection_t* font_collection, skb_font_fallback_func_t* fallback_func, void* context);
 
 /**
  * Adds OTF or TTF font to the collection from memory.
@@ -291,7 +291,7 @@ void skb_font_collection_set_on_font_fallback(skb_font_collection_t* font_collec
  * @param params (optional) pointer to font creation params, or NULL if not used.
  * @return pointer to the added font, on NULL if failed to load the font.
  */
-skb_font_handle_t skb_font_collection_add_font_from_data(
+SKB_API skb_font_handle_t skb_font_collection_add_font_from_data(
 	skb_font_collection_t* font_collection, const char* name,
 	const void* font_data, size_t font_data_length, void* context, skb_destroy_func_t* destroy_func,
 	uint8_t font_family, const skb_font_create_params_t* params);
@@ -305,7 +305,7 @@ skb_font_handle_t skb_font_collection_add_font_from_data(
  * @param params (optional) pointer to font creation params, or NULL if not used.
  * @return pointer to the added font, on NULL if failed to load the font.
  */
-skb_font_handle_t skb_font_collection_add_font(
+SKB_API skb_font_handle_t skb_font_collection_add_font(
 	skb_font_collection_t* font_collection, const char* file_name,
 	uint8_t font_family, const skb_font_create_params_t* params);
 #endif
@@ -319,7 +319,7 @@ skb_font_handle_t skb_font_collection_add_font(
  * @param params (optional) pointer to font creation params, or NULL if not used.
  * @return pointer to the added font, on NULL if failed to load the font.
  */
-skb_font_handle_t skb_font_collection_add_hb_font(
+SKB_API skb_font_handle_t skb_font_collection_add_hb_font(
 	skb_font_collection_t* font_collection, const char* name,
 	hb_font_t* hb_font, uint8_t font_family, const skb_font_create_params_t* params);
 
@@ -329,7 +329,7 @@ skb_font_handle_t skb_font_collection_add_hb_font(
  * @param font_handle handle to the font to remove.
  * @return true if the remove succeeded.
  */
-bool skb_font_collection_remove_font(skb_font_collection_t* font_collection, skb_font_handle_t font_handle);
+SKB_API bool skb_font_collection_remove_font(skb_font_collection_t* font_collection, skb_font_handle_t font_handle);
 
 /**
  * Returns fonts matching specific font properties.
@@ -347,7 +347,7 @@ bool skb_font_collection_remove_font(skb_font_collection_t* font_collection, skb
  * @param results_cap results array capacity.
  * @return number of fonts matching the parameters.
  */
-int32_t skb_font_collection_match_fonts(
+SKB_API int32_t skb_font_collection_match_fonts(
 	skb_font_collection_t* font_collection,
 	const char* lang, uint8_t script, uint8_t font_family,
 	skb_weight_t weight, skb_style_t style, skb_stretch_t stretch,
@@ -360,7 +360,7 @@ int32_t skb_font_collection_match_fonts(
  * @param codepoint codepoint to query
  * @return true of the font exists and given codepoint is supported by the font, else false.
  */
-bool skb_font_collection_font_has_codepoint(const skb_font_collection_t* font_collection, skb_font_handle_t font_handle, uint32_t codepoint);
+SKB_API bool skb_font_collection_font_has_codepoint(const skb_font_collection_t* font_collection, skb_font_handle_t font_handle, uint32_t codepoint);
 
 /**
  * Returns default font for specified font family.
@@ -369,7 +369,7 @@ bool skb_font_collection_font_has_codepoint(const skb_font_collection_t* font_co
  * @param font_family font family to query.
  * @return handle to the default font.
  */
-skb_font_handle_t skb_font_collection_get_default_font(skb_font_collection_t* font_collection, uint8_t font_family);
+SKB_API skb_font_handle_t skb_font_collection_get_default_font(skb_font_collection_t* font_collection, uint8_t font_family);
 
 /**
  * Returns font from the collection. The font pointer should not be stored for longer duration. Use skb_font_handle_t instead.
@@ -377,10 +377,10 @@ skb_font_handle_t skb_font_collection_get_default_font(skb_font_collection_t* fo
  * @param font_handle handle to the font to get from the collection.
  * @return pointer to the specified font, or NULL if not found.
  */
-skb_font_t* skb_font_collection_get_font(const skb_font_collection_t* font_collection, skb_font_handle_t font_handle);
+SKB_API skb_font_t* skb_font_collection_get_font(const skb_font_collection_t* font_collection, skb_font_handle_t font_handle);
 
 /** @returns the id of the font collection, each font collection has unique index. */
-uint32_t skb_font_collection_get_id(const skb_font_collection_t* font_collection);
+SKB_API uint32_t skb_font_collection_get_id(const skb_font_collection_t* font_collection);
 
 /**
  * Returns the bounding rect of the specified glyph.
@@ -390,7 +390,7 @@ uint32_t skb_font_collection_get_id(const skb_font_collection_t* font_collection
  * @param font_size size of the font.
  * @return rectangle descriging the bounding rect of the glyph.
  */
-skb_rect2_t skb_font_get_glyph_bounds(const skb_font_collection_t* font_collection, skb_font_handle_t font_handle, uint32_t glyph_id, float font_size);
+SKB_API skb_rect2_t skb_font_get_glyph_bounds(const skb_font_collection_t* font_collection, skb_font_handle_t font_handle, uint32_t glyph_id, float font_size);
 
 /**
  * Returns fotn metrics.
@@ -398,7 +398,7 @@ skb_rect2_t skb_font_get_glyph_bounds(const skb_font_collection_t* font_collecti
  * @param font_handle font to use.
  * @return font metrics.
  */
-skb_font_metrics_t skb_font_get_metrics(const skb_font_collection_t* font_collection, skb_font_handle_t font_handle);
+SKB_API skb_font_metrics_t skb_font_get_metrics(const skb_font_collection_t* font_collection, skb_font_handle_t font_handle);
 
 /**
  * Returns font caret metrics
@@ -406,7 +406,7 @@ skb_font_metrics_t skb_font_get_metrics(const skb_font_collection_t* font_collec
  * @param font_handle font to use.
  * @return caret metrics.
  */
-skb_caret_metrics_t skb_font_get_caret_metrics(const skb_font_collection_t* font_collection, skb_font_handle_t font_handle);
+SKB_API skb_caret_metrics_t skb_font_get_caret_metrics(const skb_font_collection_t* font_collection, skb_font_handle_t font_handle);
 
 /**
  * Returns Harfbuzz representation of the font.
@@ -414,7 +414,7 @@ skb_caret_metrics_t skb_font_get_caret_metrics(const skb_font_collection_t* font
  * @param font_handle font to use.
  * @return pointer to the Harfbuzz representation.
  */
-hb_font_t* skb_font_get_hb_font(const skb_font_collection_t* font_collection, skb_font_handle_t font_handle);
+SKB_API hb_font_t* skb_font_get_hb_font(const skb_font_collection_t* font_collection, skb_font_handle_t font_handle);
 
 /**
  * Returns specific baseline of the specified font.
@@ -426,7 +426,7 @@ hb_font_t* skb_font_get_hb_font(const skb_font_collection_t* font_collection, sk
  * @param font_size size of the font in use.
  * @return vertical location of the baseline.
  */
-float skb_font_get_baseline(const skb_font_collection_t* font_collection, skb_font_handle_t font_handle, skb_baseline_t baseline, skb_text_direction_t direction, uint8_t script, float font_size);
+SKB_API float skb_font_get_baseline(const skb_font_collection_t* font_collection, skb_font_handle_t font_handle, skb_baseline_t baseline, skb_text_direction_t direction, uint8_t script, float font_size);
 
 /**
  * Returns the baseline set of the specified font and font_size.
@@ -437,7 +437,7 @@ float skb_font_get_baseline(const skb_font_collection_t* font_collection, skb_fo
  * @param font_size size of the font in use.
  * @return
  */
-skb_baseline_set_t skb_font_get_baseline_set(const skb_font_collection_t* font_collection, const skb_font_handle_t font_handle, skb_text_direction_t direction, uint8_t script, float font_size);
+SKB_API skb_baseline_set_t skb_font_get_baseline_set(const skb_font_collection_t* font_collection, const skb_font_handle_t font_handle, skb_text_direction_t direction, uint8_t script, float font_size);
 
 /** @} */
 

--- a/include/skb_icon_collection.h
+++ b/include/skb_icon_collection.h
@@ -38,13 +38,13 @@ typedef uint32_t skb_icon_handle_t;
  * Create new icon collection.
  * @return create icon collection.
  */
-skb_icon_collection_t* skb_icon_collection_create(void);
+SKB_API skb_icon_collection_t* skb_icon_collection_create(void);
 
 /**
  * Destroy icon collection.
  * @param icon_collection icon collection to destroy.
  */
-void skb_icon_collection_destroy(skb_icon_collection_t* icon_collection);
+SKB_API void skb_icon_collection_destroy(skb_icon_collection_t* icon_collection);
 
 /**
  * Adds PicoSVG to the icon collection from memory.
@@ -55,7 +55,7 @@ void skb_icon_collection_destroy(skb_icon_collection_t* icon_collection);
  * @param icon_data_length length of the data in icon_data in bytes.
  * @return pointer to the added icon, or NULL if failed.
  */
-skb_icon_handle_t skb_icon_collection_add_picosvg_icon_from_data(skb_icon_collection_t* icon_collection, const char* name, const char* icon_data, const int32_t icon_data_length);
+SKB_API skb_icon_handle_t skb_icon_collection_add_picosvg_icon_from_data(skb_icon_collection_t* icon_collection, const char* name, const char* icon_data, const int32_t icon_data_length);
 
 #if !defined(SKB_NO_OPEN)
 /**
@@ -65,7 +65,7 @@ skb_icon_handle_t skb_icon_collection_add_picosvg_icon_from_data(skb_icon_collec
  * @param file_name name of the icon to add.
  * @return pointer to the added icon, or NULL if failed.
  */
-skb_icon_handle_t skb_icon_collection_add_picosvg_icon(skb_icon_collection_t* icon_collection, const char* name, const char* file_name);
+SKB_API skb_icon_handle_t skb_icon_collection_add_picosvg_icon(skb_icon_collection_t* icon_collection, const char* name, const char* file_name);
 #endif // !defined(SKB_NO_OPEN)
 
 /**
@@ -77,7 +77,7 @@ skb_icon_handle_t skb_icon_collection_add_picosvg_icon(skb_icon_collection_t* ic
  * @param height height of the icon to create.
  * @return pointer to the added icon, or 0 if failed.
  */
-skb_icon_handle_t skb_icon_collection_add_icon(skb_icon_collection_t* icon_collection, const char* name, float width, float height);
+SKB_API skb_icon_handle_t skb_icon_collection_add_icon(skb_icon_collection_t* icon_collection, const char* name, float width, float height);
 
 /**
  * Removes icons from collection.
@@ -85,7 +85,7 @@ skb_icon_handle_t skb_icon_collection_add_icon(skb_icon_collection_t* icon_colle
  * @param icon_handle handle to icon to remove.
  * @return true if the icon was removes.
  */
-bool skb_icon_collection_remove_icon(skb_icon_collection_t* icon_collection, skb_icon_handle_t icon_handle);
+SKB_API bool skb_icon_collection_remove_icon(skb_icon_collection_t* icon_collection, skb_icon_handle_t icon_handle);
 
 /**
  * Finds an icon based on name.
@@ -93,7 +93,7 @@ bool skb_icon_collection_remove_icon(skb_icon_collection_t* icon_collection, skb
  * @param name name of the icon to query.
  * @return pointer to the icon, or NULL if not found.
  */
-skb_icon_handle_t skb_icon_collection_find_icon(const skb_icon_collection_t* icon_collection, const char* name);
+SKB_API skb_icon_handle_t skb_icon_collection_find_icon(const skb_icon_collection_t* icon_collection, const char* name);
 
 /**
  * Set whether the icon should be rendered as RGBA or alpha mask.
@@ -102,7 +102,7 @@ skb_icon_handle_t skb_icon_collection_find_icon(const skb_icon_collection_t* ico
  * @param icon_handle handle to icon to modify.
  * @param is_color if true, the icon will be rendered as RGBA, if false, the icon will be rendered as alpha mask.
  */
-void skb_icon_collection_set_is_color(skb_icon_collection_t* icon_collection, skb_icon_handle_t icon_handle, bool is_color);
+SKB_API void skb_icon_collection_set_is_color(skb_icon_collection_t* icon_collection, skb_icon_handle_t icon_handle, bool is_color);
 
 /**
  * Calculates proportional scale to render icon at specific size.
@@ -114,7 +114,7 @@ void skb_icon_collection_set_is_color(skb_icon_collection_t* icon_collection, sk
  * @param height requested with, if SKB_SIZE_AUTO the result y scale is same as x scale.
  * @return how much to scale the icon to get requested size.
  */
-skb_vec2_t skb_icon_collection_calc_proportional_scale(const skb_icon_collection_t* icon_collection, skb_icon_handle_t icon_handle, float width, float height);
+SKB_API skb_vec2_t skb_icon_collection_calc_proportional_scale(const skb_icon_collection_t* icon_collection, skb_icon_handle_t icon_handle, float width, float height);
 
 /**
  * Calculates proportional size of the icon given either width or height.
@@ -124,10 +124,10 @@ skb_vec2_t skb_icon_collection_calc_proportional_scale(const skb_icon_collection
  * @param height requested with, if SKB_SIZE_AUTO the height will be calculated from width keeping aspect ratio.
  * @return size of the icon.
  */
-skb_vec2_t skb_icon_collection_calc_proportional_size(const skb_icon_collection_t* icon_collection, skb_icon_handle_t icon_handle, float width, float height);
+SKB_API skb_vec2_t skb_icon_collection_calc_proportional_size(const skb_icon_collection_t* icon_collection, skb_icon_handle_t icon_handle, float width, float height);
 
 /** @return size of the icon. */
-skb_vec2_t skb_icon_collection_get_icon_size(const skb_icon_collection_t* icon_collection, skb_icon_handle_t icon_handle);
+SKB_API skb_vec2_t skb_icon_collection_get_icon_size(const skb_icon_collection_t* icon_collection, skb_icon_handle_t icon_handle);
 
 /**
  * Returns pointer to an icon. The icon pointer should not be stored for longer duration. Use skb_font_handle_t instead.
@@ -135,10 +135,10 @@ skb_vec2_t skb_icon_collection_get_icon_size(const skb_icon_collection_t* icon_c
  * @param icon_handle handle to the icon to query.
  * @return pointer to the specified icon.
  */
-const skb_icon_t* skb_icon_collection_get_icon(const skb_icon_collection_t* icon_collection, skb_icon_handle_t icon_handle);
+SKB_API const skb_icon_t* skb_icon_collection_get_icon(const skb_icon_collection_t* icon_collection, skb_icon_handle_t icon_handle);
 
 /** @returns the id of the icon collection, each icon collection has unique index. */
-uint32_t skb_icon_collection_get_id(const skb_icon_collection_t* icon_collection);
+SKB_API uint32_t skb_icon_collection_get_id(const skb_icon_collection_t* icon_collection);
 
 //
 // Icon Builder
@@ -164,33 +164,33 @@ typedef struct skb_icon_builder_t {
  * @param icon_handle icon handle to build.
  * @return
  */
-skb_icon_builder_t skb_icon_builder_make(skb_icon_collection_t* icon_collection, skb_icon_handle_t icon_handle);
+SKB_API skb_icon_builder_t skb_icon_builder_make(skb_icon_collection_t* icon_collection, skb_icon_handle_t icon_handle);
 
 /**
  * Begin new shape. Can be nested to create groups.
  * @param icon_builder pointer to icon builder.
  */
-void skb_icon_builder_begin_shape(skb_icon_builder_t* icon_builder);
+SKB_API void skb_icon_builder_begin_shape(skb_icon_builder_t* icon_builder);
 
 /**
  * Ends shape or group.
  * @param icon_builder pointer to icon builder.
  */
-void skb_icon_builder_end_shape(skb_icon_builder_t* icon_builder);
+SKB_API void skb_icon_builder_end_shape(skb_icon_builder_t* icon_builder);
 
 /**
  * Starts a new path in the current shape.
  * @param icon_builder pointer to icon builder.
  * @param pt starting point of the path.
  */
-void skb_icon_builder_move_to(skb_icon_builder_t* icon_builder, skb_vec2_t pt);
+SKB_API void skb_icon_builder_move_to(skb_icon_builder_t* icon_builder, skb_vec2_t pt);
 
 /**
  * Appends line to the current path.
  * @param icon_builder
  * @param pt line end position.
  */
-void skb_icon_builder_line_to(skb_icon_builder_t* icon_builder, skb_vec2_t pt);
+SKB_API void skb_icon_builder_line_to(skb_icon_builder_t* icon_builder, skb_vec2_t pt);
 
 /**
  * Appends quadratic bezier segment to the current path.
@@ -198,7 +198,7 @@ void skb_icon_builder_line_to(skb_icon_builder_t* icon_builder, skb_vec2_t pt);
  * @param cp control point of the curve.
  * @param pt curve end position.
  */
-void skb_icon_builder_quad_to(skb_icon_builder_t* icon_builder, skb_vec2_t cp, skb_vec2_t pt);
+SKB_API void skb_icon_builder_quad_to(skb_icon_builder_t* icon_builder, skb_vec2_t cp, skb_vec2_t pt);
 
 /**
  * Appends cubic bezier segment to the current path.
@@ -207,27 +207,27 @@ void skb_icon_builder_quad_to(skb_icon_builder_t* icon_builder, skb_vec2_t cp, s
  * @param cp1 second control point of the curve.
  * @param pt curve end position.
  */
-void skb_icon_builder_cubic_to(skb_icon_builder_t* icon_builder, skb_vec2_t cp0, skb_vec2_t cp1, skb_vec2_t pt);
+SKB_API void skb_icon_builder_cubic_to(skb_icon_builder_t* icon_builder, skb_vec2_t cp0, skb_vec2_t cp1, skb_vec2_t pt);
 
 /**
  * Closes the current path byt connect the last point to start point.
  * @param icon_builder pointer to icon builder.
  */
-void skb_icon_builder_close_path(skb_icon_builder_t* icon_builder);
+SKB_API void skb_icon_builder_close_path(skb_icon_builder_t* icon_builder);
 
 /**
  * Sets the opacity of current shape.
  * @param icon_builder pointer to icon builder.
  * @param opacity
  */
-void skb_icon_builder_fill_opacity(skb_icon_builder_t* icon_builder, float opacity);
+SKB_API void skb_icon_builder_fill_opacity(skb_icon_builder_t* icon_builder, float opacity);
 
 /**
  * Sets the fill of the current shape to solid color.
  * @param icon_builder pointer to icon builder.
  * @param color color to set
  */
-void skb_icon_builder_fill_color(skb_icon_builder_t* icon_builder, skb_color_t color);
+SKB_API void skb_icon_builder_fill_color(skb_icon_builder_t* icon_builder, skb_color_t color);
 
 /**
  * Sets the fill of the current shape to a linear gradient.
@@ -239,7 +239,7 @@ void skb_icon_builder_fill_color(skb_icon_builder_t* icon_builder, skb_color_t c
  * @param stops color stops for the gradient.
  * @param stops_count number of color stops.
  */
-void skb_icon_builder_fill_linear_gradient(skb_icon_builder_t* icon_builder, skb_vec2_t p0, skb_vec2_t p1, skb_mat2_t xform, skb_gradient_spread_t spread, skb_color_stop_t* stops, int32_t stops_count);
+SKB_API void skb_icon_builder_fill_linear_gradient(skb_icon_builder_t* icon_builder, skb_vec2_t p0, skb_vec2_t p1, skb_mat2_t xform, skb_gradient_spread_t spread, skb_color_stop_t* stops, int32_t stops_count);
 
 /**
  * Sets the fill of the current shape to a radial gradient.
@@ -252,7 +252,7 @@ void skb_icon_builder_fill_linear_gradient(skb_icon_builder_t* icon_builder, skb
  * @param stops color stops for the gradient.
  * @param stops_count number of color stops.
  */
-void skb_icon_builder_fill_radial_gradient(skb_icon_builder_t* icon_builder, skb_vec2_t p0, skb_vec2_t p1, float radius, skb_mat2_t xform, skb_gradient_spread_t spread, skb_color_stop_t* stops, int32_t stops_count);
+SKB_API void skb_icon_builder_fill_radial_gradient(skb_icon_builder_t* icon_builder, skb_vec2_t p0, skb_vec2_t p1, float radius, skb_mat2_t xform, skb_gradient_spread_t spread, skb_color_stop_t* stops, int32_t stops_count);
 
 /** @} */
 

--- a/include/skb_image_atlas.h
+++ b/include/skb_image_atlas.h
@@ -156,26 +156,26 @@ typedef struct skb_image_atlas_config_t {
  * @param config configuration to use for the new image atlas.
  * @return pointer to the created image atlas.
  */
-skb_image_atlas_t* skb_image_atlas_create(const skb_image_atlas_config_t* config);
+SKB_API skb_image_atlas_t* skb_image_atlas_create(const skb_image_atlas_config_t* config);
 
 /**
  * Destroys a image atlas created with skb_image_atlas_create().
  * @param atlas pointer to the atlas to destroy.
  */
-void skb_image_atlas_destroy(skb_image_atlas_t* atlas);
+SKB_API void skb_image_atlas_destroy(skb_image_atlas_t* atlas);
 
 /**
  * Returns default values for image atlas config. Useful if you only want to change some specific values.
  * @return image atlas config default values.
  */
-skb_image_atlas_config_t skb_image_atlas_get_default_config(void);
+SKB_API skb_image_atlas_config_t skb_image_atlas_get_default_config(void);
 
 /**
  * Returns the config used to create the image atlas.
  * @param atlas atlas to use.
  * @return config for the specified image atlas.
  */
-skb_image_atlas_config_t skb_image_atlas_get_config(skb_image_atlas_t* atlas);
+SKB_API skb_image_atlas_config_t skb_image_atlas_get_config(skb_image_atlas_t* atlas);
 
 /**
  * Sets the texture creation callback of the image atlas.
@@ -183,10 +183,10 @@ skb_image_atlas_config_t skb_image_atlas_get_config(skb_image_atlas_t* atlas);
  * @param create_texture_callback pointer to the callback function.
  * @param context pointer passed to the callback function each time it is called.
  */
-void skb_image_atlas_set_create_texture_callback(skb_image_atlas_t* atlas, skb_create_texture_func_t* create_texture_callback, void* context);
+SKB_API void skb_image_atlas_set_create_texture_callback(skb_image_atlas_t* atlas, skb_create_texture_func_t* create_texture_callback, void* context);
 
 /** @return number of textures in the atlas. */
-int32_t skb_image_atlas_get_texture_count(skb_image_atlas_t* atlas);
+SKB_API int32_t skb_image_atlas_get_texture_count(skb_image_atlas_t* atlas);
 
 /**
  * Returns texture at specified index. See skb_image_atlas_get_texture_count() to get number of textures.
@@ -194,7 +194,7 @@ int32_t skb_image_atlas_get_texture_count(skb_image_atlas_t* atlas);
  * @param texture_idx index of the texture to get.
  * @return pointer to the spcified image.
  */
-const skb_image_t* skb_image_atlas_get_texture(skb_image_atlas_t* atlas, int32_t texture_idx);
+SKB_API const skb_image_t* skb_image_atlas_get_texture(skb_image_atlas_t* atlas, int32_t texture_idx);
 
 /**
  * Returns the bounding rect of the modified portion of the specified texture. See skb_image_atlas_get_textures_count() to get number of textures.
@@ -202,7 +202,7 @@ const skb_image_t* skb_image_atlas_get_texture(skb_image_atlas_t* atlas, int32_t
  * @param texture_idx index of the image to query.
  * @return bounding rect of the modified portion of the image.
  */
-skb_rect2i_t skb_image_atlas_get_texture_dirty_bounds(skb_image_atlas_t* atlas, int32_t texture_idx);
+SKB_API skb_rect2i_t skb_image_atlas_get_texture_dirty_bounds(skb_image_atlas_t* atlas, int32_t texture_idx);
 
 /**
  * Returns the bounding rect of the modified portion of the specified texture, and resets the bounding rectangle.
@@ -211,7 +211,7 @@ skb_rect2i_t skb_image_atlas_get_texture_dirty_bounds(skb_image_atlas_t* atlas, 
  * @param texture_idx index of the image to query.
  * @return bounding rect of the modified portion of the texture.
  */
-skb_rect2i_t skb_image_atlas_get_and_reset_texture_dirty_bounds(skb_image_atlas_t* atlas, int32_t texture_idx);
+SKB_API skb_rect2i_t skb_image_atlas_get_and_reset_texture_dirty_bounds(skb_image_atlas_t* atlas, int32_t texture_idx);
 
 /**
  * Sets user data for a specified texture.
@@ -220,7 +220,7 @@ skb_rect2i_t skb_image_atlas_get_and_reset_texture_dirty_bounds(skb_image_atlas_
  * @param texture_idx index of the image.
  * @param user_data user date to store.
  */
-void skb_image_atlas_set_texture_user_data(skb_image_atlas_t* atlas, int32_t texture_idx, uintptr_t user_data);
+SKB_API void skb_image_atlas_set_texture_user_data(skb_image_atlas_t* atlas, int32_t texture_idx, uintptr_t user_data);
 
 /**
  * Gets user data set for specified image.
@@ -229,7 +229,7 @@ void skb_image_atlas_set_texture_user_data(skb_image_atlas_t* atlas, int32_t tex
  * @param texture_idx index of the texture.
  * @return user data.
  */
-uintptr_t skb_image_atlas_get_texture_user_data(skb_image_atlas_t* image_atlas, int32_t texture_idx);
+SKB_API uintptr_t skb_image_atlas_get_texture_user_data(skb_image_atlas_t* image_atlas, int32_t texture_idx);
 
 /**
  * Signature of rectangle iterator functions.
@@ -248,7 +248,7 @@ typedef void skb_debug_rect_iterator_func_t(int32_t x, int32_t y, int32_t width,
  * @param callback callback that is called for each free space rectangle in the atlas.
  * @param context contest pointer passed to the callback.
  */
-void skb_image_atlas_debug_iterate_free_rects(skb_image_atlas_t* atlas, int32_t texture_idx, skb_debug_rect_iterator_func_t* callback, void* context);
+SKB_API void skb_image_atlas_debug_iterate_free_rects(skb_image_atlas_t* atlas, int32_t texture_idx, skb_debug_rect_iterator_func_t* callback, void* context);
 
 /**
  * Iterates over all the used rectangles in a specific image. Used for debugging.
@@ -257,7 +257,7 @@ void skb_image_atlas_debug_iterate_free_rects(skb_image_atlas_t* atlas, int32_t 
  * @param callback callback that is called for each used rectangle in the atlas.
  * @param context contest pointer passed to the callback.
  */
-void skb_image_atlas_debug_iterate_used_rects(skb_image_atlas_t* atlas, int32_t texture_idx, skb_debug_rect_iterator_func_t* callback, void* context);
+SKB_API void skb_image_atlas_debug_iterate_used_rects(skb_image_atlas_t* atlas, int32_t texture_idx, skb_debug_rect_iterator_func_t* callback, void* context);
 
 /**
  * Returns previous non-empty dirty bounds of the specified texture. Can be used to visualize the last update region.
@@ -265,7 +265,7 @@ void skb_image_atlas_debug_iterate_used_rects(skb_image_atlas_t* atlas, int32_t 
  * @param texture_idx index of the texture.
  * @return previous dirty rectangle.
  */
-skb_rect2i_t skb_image_atlas_debug_get_texture_prev_dirty_bounds(skb_image_atlas_t* atlas, int32_t texture_idx);
+SKB_API skb_rect2i_t skb_image_atlas_debug_get_texture_prev_dirty_bounds(skb_image_atlas_t* atlas, int32_t texture_idx);
 
 
 /**
@@ -289,7 +289,7 @@ skb_rect2i_t skb_image_atlas_debug_get_texture_prev_dirty_bounds(skb_image_atlas
  * @param alpha_mode whether to render the glyph as SDF or alpha mask.
  * @return quad representing the geometry to render, and portion of an image to use.
  */
-skb_quad_t skb_image_atlas_get_glyph_quad(
+SKB_API skb_quad_t skb_image_atlas_get_glyph_quad(
 	skb_image_atlas_t* atlas, float x, float y, float pixel_scale,
 	skb_font_collection_t* font_collection, skb_font_handle_t font_handle, uint32_t glyph_id, float font_size,
 	skb_color_t tint_color, skb_rasterize_alpha_mode_t alpha_mode);
@@ -315,7 +315,7 @@ skb_quad_t skb_image_atlas_get_glyph_quad(
  * @param alpha_mode whether to render the icon as SDF or alpha mask.
  * @return quad representing the geometry to render, and portion of an image to use.
  */
-skb_quad_t skb_image_atlas_get_icon_quad(
+SKB_API skb_quad_t skb_image_atlas_get_icon_quad(
 	skb_image_atlas_t* atlas, float x, float y, float pixel_scale,
 	const skb_icon_collection_t* icon_collection, skb_icon_handle_t icon_handle, float width, float height,
 	skb_color_t tint_color, skb_rasterize_alpha_mode_t alpha_mode);
@@ -342,7 +342,7 @@ skb_quad_t skb_image_atlas_get_icon_quad(
  * @param alpha_mode whether to render the pattern as SDF or alpha mask.
  * @return quad representing the geometry to render, and portion of an image to use.
  */
-skb_quad_t skb_image_atlas_get_decoration_quad(
+SKB_API skb_quad_t skb_image_atlas_get_decoration_quad(
 	skb_image_atlas_t* atlas, float x, float y, float pixel_scale,
 	skb_decoration_position_t position, skb_decoration_style_t style, float length, float pattern_offset, float thickness,
 	skb_color_t tint_color, skb_rasterize_alpha_mode_t alpha_mode);
@@ -354,7 +354,7 @@ skb_quad_t skb_image_atlas_get_decoration_quad(
  * @param atlas atlas to use.
  * @return true if any items were removed.
  */
-bool skb_image_atlas_compact(skb_image_atlas_t* atlas);
+SKB_API bool skb_image_atlas_compact(skb_image_atlas_t* atlas);
 
 /**
  * Rasterizes glyphs and icons that have been requested.
@@ -368,7 +368,7 @@ bool skb_image_atlas_compact(skb_image_atlas_t* atlas);
  * @param rasterizer renderer to use during rasterization.
  * @return true if any images were changed.
  */
-bool skb_image_atlas_rasterize_missing_items(skb_image_atlas_t* atlas, skb_temp_alloc_t* temp_alloc, skb_rasterizer_t* rasterizer);
+SKB_API bool skb_image_atlas_rasterize_missing_items(skb_image_atlas_t* atlas, skb_temp_alloc_t* temp_alloc, skb_rasterizer_t* rasterizer);
 
 /** @} */
 

--- a/include/skb_layout.h
+++ b/include/skb_layout.h
@@ -170,7 +170,7 @@ typedef struct skb_content_run_t {
  * @param content_id id representing the run, id of 0 is treated as invalid, in which case the run cannot be queried.
  * @return initialized content run.
  */
-skb_content_run_t skb_content_run_make_utf8(const char* text, int32_t text_count, skb_attribute_set_t attributes, intptr_t content_id);
+SKB_API skb_content_run_t skb_content_run_make_utf8(const char* text, int32_t text_count, skb_attribute_set_t attributes, intptr_t content_id);
 
 /**
  * Makes utf-32 content run.
@@ -184,7 +184,7 @@ skb_content_run_t skb_content_run_make_utf8(const char* text, int32_t text_count
  * @param content_id id representing the run, id of 0 is treated as empty, in which case the run is ignored by content queries.
  * @return initialized content run.
  */
-skb_content_run_t skb_content_run_make_utf32(const uint32_t* text, int32_t text_count, skb_attribute_set_t attributes, intptr_t content_id);
+SKB_API skb_content_run_t skb_content_run_make_utf32(const uint32_t* text, int32_t text_count, skb_attribute_set_t attributes, intptr_t content_id);
 
 /**
  * Makes inline object content run.
@@ -203,7 +203,7 @@ skb_content_run_t skb_content_run_make_utf32(const uint32_t* text, int32_t text_
  * @return initialized content run.
  * @param content_id id representing the run, id of 0 is treated as empty, in which case the run is ignored by content queries.
  */
-skb_content_run_t skb_content_run_make_object(intptr_t data, float width, float height, skb_attribute_set_t attributes, intptr_t content_id);
+SKB_API skb_content_run_t skb_content_run_make_object(intptr_t data, float width, float height, skb_attribute_set_t attributes, intptr_t content_id);
 
 /**
  * Makes inline icon content run.
@@ -224,7 +224,7 @@ skb_content_run_t skb_content_run_make_object(intptr_t data, float width, float 
  * @param content_id id representing the run, id of 0 is treated as empty, in which case the run is ignored by content queries.
  * @return initialized content run.
  */
-skb_content_run_t skb_content_run_make_icon(skb_icon_handle_t icon_handle, float width, float height, skb_attribute_set_t attributes, intptr_t content_id);
+SKB_API skb_content_run_t skb_content_run_make_icon(skb_icon_handle_t icon_handle, float width, float height, skb_attribute_set_t attributes, intptr_t content_id);
 
 /** Enum describing flags for skb_layout_line_t. */
 typedef enum {
@@ -456,14 +456,14 @@ typedef struct skb_layout_t skb_layout_t;
  * @param params pointer to the parameters to hash.
  * @return combined hash.
  */
-uint64_t skb_layout_params_hash_append(uint64_t hash, const skb_layout_params_t* params);
+SKB_API uint64_t skb_layout_params_hash_append(uint64_t hash, const skb_layout_params_t* params);
 
 /**
  * Creates empty layout with specified parameters.
  * @param params parameters to use for the layout.
  * @return newly create empty layout.
  */
-skb_layout_t* skb_layout_create(const skb_layout_params_t* params);
+SKB_API skb_layout_t* skb_layout_create(const skb_layout_params_t* params);
 
 /**
  * Creates new layout from the provided parameters, text and text attributes.
@@ -474,7 +474,7 @@ skb_layout_t* skb_layout_create(const skb_layout_params_t* params);
  * @param attributes attributes to apply for the text.
  * @return newly create layout.
  */
-skb_layout_t* skb_layout_create_utf8(
+SKB_API skb_layout_t* skb_layout_create_utf8(
 	skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params,
 	const char* text, int32_t text_count, skb_attribute_set_t attributes);
 
@@ -487,7 +487,7 @@ skb_layout_t* skb_layout_create_utf8(
  * @param attributes attributes to apply for the text.
  * @return newly create layout.
  */
-skb_layout_t* skb_layout_create_utf32(
+SKB_API skb_layout_t* skb_layout_create_utf32(
 	skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params,
 	const uint32_t* text, int32_t text_count, skb_attribute_set_t attributes);
 
@@ -500,7 +500,7 @@ skb_layout_t* skb_layout_create_utf32(
  * @param runs_count number of runs.
  * @return newly create layout.
  */
-skb_layout_t* skb_layout_create_from_runs(
+SKB_API skb_layout_t* skb_layout_create_from_runs(
 	skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params,
 	const skb_content_run_t* runs, int32_t runs_count);
 
@@ -511,7 +511,7 @@ skb_layout_t* skb_layout_create_from_runs(
  * @param text pointer to the text to copy the text and attributes from.
  * @return newly create layout.
  */
-skb_layout_t* skb_layout_create_from_text(skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const skb_text_t* text, skb_attribute_set_t attributes);
+SKB_API skb_layout_t* skb_layout_create_from_text(skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params, const skb_text_t* text, skb_attribute_set_t attributes);
 
 /**
  * Sets the layout from the provided parameters, text and text attributes.
@@ -523,7 +523,7 @@ skb_layout_t* skb_layout_create_from_text(skb_temp_alloc_t* temp_alloc, const sk
  * @param attributes attributes to apply for the text.
  * @return newly create layout.
  */
-void skb_layout_set_utf8(
+SKB_API void skb_layout_set_utf8(
 	skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params,
 	const char* text, int32_t text_count, skb_attribute_set_t attributes);
 
@@ -537,7 +537,7 @@ void skb_layout_set_utf8(
  * @param attributes attributes to apply for the text.
  * @return newly create layout.
  */
-void skb_layout_set_utf32(
+SKB_API void skb_layout_set_utf32(
 	skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params,
 	const uint32_t* text, int32_t text_count, skb_attribute_set_t attributes);
 
@@ -550,7 +550,7 @@ void skb_layout_set_utf32(
  * @param runs utf-8 text runs to combine into continuous text.
  * @param runs_count number of runs.
  */
-void skb_layout_set_from_runs(
+SKB_API void skb_layout_set_from_runs(
 	skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params,
 	const skb_content_run_t* runs, int32_t runs_count);
 
@@ -562,7 +562,7 @@ void skb_layout_set_from_runs(
  * @param params paramters to use for the layout.
  * @param text pointer to the text to copy the text and attributes from.
  */
-void skb_layout_set_from_text(
+SKB_API void skb_layout_set_from_text(
 	skb_layout_t* layout, skb_temp_alloc_t* temp_alloc, const skb_layout_params_t* params,
 	const skb_text_t* text, skb_attribute_set_t attributes);
 
@@ -570,67 +570,67 @@ void skb_layout_set_from_text(
  * Empties the specified layout. Keeps the existing allocations.
  * @param layout layout to reset.
  */
-void skb_layout_reset(skb_layout_t* layout);
+SKB_API void skb_layout_reset(skb_layout_t* layout);
 
 /**
  * Destroys specified layout.
  * @param layout layout to destroy.
  */
-void skb_layout_destroy(skb_layout_t* layout);
+SKB_API void skb_layout_destroy(skb_layout_t* layout);
 
 /**
  * Returns parameters that were used to create th elayout.
  * @param layout layout to use
  * @return const pointer to the parameters.
  */
-const skb_layout_params_t* skb_layout_get_params(const skb_layout_t* layout);
+SKB_API const skb_layout_params_t* skb_layout_get_params(const skb_layout_t* layout);
 
 /** @return number of codepoints in the layout text. */
-int32_t skb_layout_get_text_count(const skb_layout_t* layout);
+SKB_API int32_t skb_layout_get_text_count(const skb_layout_t* layout);
 /** @return const pointer to the codepoints of the text. See skb_layout_get_text_count() to get text length. */
-const uint32_t* skb_layout_get_text(const skb_layout_t* layout);
+SKB_API const uint32_t* skb_layout_get_text(const skb_layout_t* layout);
 /** @return const pointer to the codepoint properties of the text. See skb_layout_get_text_count() to get text length. */
-const skb_text_property_t* skb_layout_get_text_properties(const skb_layout_t* layout);
+SKB_API const skb_text_property_t* skb_layout_get_text_properties(const skb_layout_t* layout);
 
 /** @return number of layout runs in the layout. */
-int32_t skb_layout_get_layout_runs_count(const skb_layout_t* layout);
+SKB_API int32_t skb_layout_get_layout_runs_count(const skb_layout_t* layout);
 /** @return const pointer to the layout runs. See skb_layout_get_layout_runs_count() to get number of glyph runs. */
-const skb_layout_run_t* skb_layout_get_layout_runs(const skb_layout_t* layout);
+SKB_API const skb_layout_run_t* skb_layout_get_layout_runs(const skb_layout_t* layout);
 
 /** @return number of glyphs in the layout. */
-int32_t skb_layout_get_glyphs_count(const skb_layout_t* layout);
+SKB_API int32_t skb_layout_get_glyphs_count(const skb_layout_t* layout);
 /** @return const pointer to the glyphs. See skb_layout_get_glyphs_count() to get number of glyphs. */
-const skb_glyph_t* skb_layout_get_glyphs(const skb_layout_t* layout);
+SKB_API const skb_glyph_t* skb_layout_get_glyphs(const skb_layout_t* layout);
 
 /** @return number of clusters in the layout. */
-int32_t skb_layout_get_clusters_count(const skb_layout_t* layout);
+SKB_API int32_t skb_layout_get_clusters_count(const skb_layout_t* layout);
 /** @return const pointer to the clusters. See skb_layout_get_clusters_count() to get number of clusters. */
-const skb_cluster_t* skb_layout_get_clusters(const skb_layout_t* layout);
+SKB_API const skb_cluster_t* skb_layout_get_clusters(const skb_layout_t* layout);
 
 /** @return number of decorations in the layout. */
-int32_t skb_layout_get_decorations_count(const skb_layout_t* layout);
+SKB_API int32_t skb_layout_get_decorations_count(const skb_layout_t* layout);
 /** @return const pointer to the lines. See skb_layout_get_decorations_count() to get number of decorations. */
-const skb_decoration_t* skb_layout_get_decorations(const skb_layout_t* layout);
+SKB_API const skb_decoration_t* skb_layout_get_decorations(const skb_layout_t* layout);
 
 /** @return number of lines in the layout. */
-int32_t skb_layout_get_lines_count(const skb_layout_t* layout);
+SKB_API int32_t skb_layout_get_lines_count(const skb_layout_t* layout);
 /** @return const pointer to the lines. See skb_layout_get_lines_count() to get number of lines. */
-const skb_layout_line_t* skb_layout_get_lines(const skb_layout_t* layout);
+SKB_API const skb_layout_line_t* skb_layout_get_lines(const skb_layout_t* layout);
 
 /** @returns attribute set for specified layout run*/
-skb_attribute_set_t skb_layout_get_layout_run_attributes(const skb_layout_t* layout, const skb_layout_run_t* run);
+SKB_API skb_attribute_set_t skb_layout_get_layout_run_attributes(const skb_layout_t* layout, const skb_layout_run_t* run);
 
 /** @returns content bounds (without padding) for specified layout run*/
-skb_rect2_t skb_layout_get_layout_run_content_bounds(const skb_layout_t* layout, const skb_layout_run_t* run);
+SKB_API skb_rect2_t skb_layout_get_layout_run_content_bounds(const skb_layout_t* layout, const skb_layout_run_t* run);
 
 /** @return bounds of the layout including padding. */
-skb_rect2_t skb_layout_get_bounds(const skb_layout_t* layout);
+SKB_API skb_rect2_t skb_layout_get_bounds(const skb_layout_t* layout);
 
 /** @return bounds of the layout content (without padding). */
-skb_rect2_t skb_layout_get_content_bounds(const skb_layout_t* layout);
+SKB_API skb_rect2_t skb_layout_get_content_bounds(const skb_layout_t* layout);
 
 /** @return padding applied to the layout. */
-skb_padding2_t skb_layout_get_padding(const skb_layout_t* layout);
+SKB_API skb_padding2_t skb_layout_get_padding(const skb_layout_t* layout);
 
 /** Enum describing flags for skb_layout_t. */
 typedef enum {
@@ -638,17 +638,17 @@ typedef enum {
 	SKB_LAYOUT_IS_TRUNCATED	= 1 << 0,
 } skb_layout_flags_t;
 
-uint32_t skb_layout_get_flags(const skb_layout_t* layout);
+SKB_API uint32_t skb_layout_get_flags(const skb_layout_t* layout);
 
 /**
  * Returns how much to advance the y position when layouts are stacked.
  * @param layout layout to query
  * @return y advance
  */
-float skb_layout_get_advance_y(const skb_layout_t* layout);
+SKB_API float skb_layout_get_advance_y(const skb_layout_t* layout);
 
 /** @return text direction of the layout, if the direction was auto, the direction inferred from the text. */
-skb_text_direction_t skb_layout_get_resolved_direction(const skb_layout_t* layout);
+SKB_API skb_text_direction_t skb_layout_get_resolved_direction(const skb_layout_t* layout);
 
 /**
  * Get the start of the next grapheme in the layout based on text offset.
@@ -656,7 +656,7 @@ skb_text_direction_t skb_layout_get_resolved_direction(const skb_layout_t* layou
  * @param text_offset offset (codepoints) in the text where to start looking.
  * @return offset (codepoints) to the start of the next grapheme.
  */
-int32_t skb_layout_get_next_grapheme_offset(const skb_layout_t* layout, int32_t text_offset);
+SKB_API int32_t skb_layout_get_next_grapheme_offset(const skb_layout_t* layout, int32_t text_offset);
 
 /**
  * Get the start of the previous grapheme in the layout based on text offset.
@@ -664,7 +664,7 @@ int32_t skb_layout_get_next_grapheme_offset(const skb_layout_t* layout, int32_t 
  * @param text_offset offset (codepoints) in the text where to start looking.
  * @return offset (codepoints) to the start of the previous grapheme.
  */
-int32_t skb_layout_get_prev_grapheme_offset(const skb_layout_t* layout, int32_t text_offset);
+SKB_API int32_t skb_layout_get_prev_grapheme_offset(const skb_layout_t* layout, int32_t text_offset);
 
 /**
  * Get the start of the current grapheme in the layout based on text offset.
@@ -672,7 +672,7 @@ int32_t skb_layout_get_prev_grapheme_offset(const skb_layout_t* layout, int32_t 
  * @param text_offset offset (codepoints) in the text where to start looking.
  * @return offset (codepoints) to the start of the current grapheme.
  */
-int32_t skb_layout_align_grapheme_offset(const skb_layout_t* layout, int32_t text_offset);
+SKB_API int32_t skb_layout_align_grapheme_offset(const skb_layout_t* layout, int32_t text_offset);
 
 //
 // Text Selection
@@ -703,7 +703,7 @@ typedef struct skb_caret_info_t {
  * @param pos position within the text.
  * @return zero based line number.
  */
-int32_t skb_layout_get_line_index(const skb_layout_t* layout, skb_text_position_t pos);
+SKB_API int32_t skb_layout_get_line_index(const skb_layout_t* layout, skb_text_position_t pos);
 
 /**
  * Returns the text offset (codepoint) from specific text position, taking affinity into account.
@@ -711,7 +711,7 @@ int32_t skb_layout_get_line_index(const skb_layout_t* layout, skb_text_position_
  * @param pos position within the text.
  * @return text offset.
  */
-int32_t skb_layout_get_offset_from_text_position(const skb_layout_t* layout, skb_text_position_t pos);
+SKB_API int32_t skb_layout_get_offset_from_text_position(const skb_layout_t* layout, skb_text_position_t pos);
 
 /**
  * Returns text direction at the specified text postition.
@@ -719,7 +719,7 @@ int32_t skb_layout_get_offset_from_text_position(const skb_layout_t* layout, skb
  * @param pos position within the text.
  * @return text direction at the specified text postition.
  */
-skb_text_direction_t skb_layout_get_text_direction_at(const skb_layout_t* layout, skb_text_position_t pos);
+SKB_API skb_text_direction_t skb_layout_get_text_direction_at(const skb_layout_t* layout, skb_text_position_t pos);
 
 
 /** Enum describing intended movement. Caret movement and selection cursor movement have diffent behavior at the end of hte line. */
@@ -739,7 +739,7 @@ typedef enum {
  * @param hit_x hit X location.
  * @return text position under the specified hit location.
  */
-skb_text_position_t skb_layout_hit_test_at_line(const skb_layout_t* layout, skb_movement_type_t type, int32_t line_idx, float hit_x);
+SKB_API skb_text_position_t skb_layout_hit_test_at_line(const skb_layout_t* layout, skb_movement_type_t type, int32_t line_idx, float hit_x);
 
 /**
  * Returns caret text position under the hit location.
@@ -751,7 +751,7 @@ skb_text_position_t skb_layout_hit_test_at_line(const skb_layout_t* layout, skb_
  * @param hit_y hit Y location
  * @return caret text position under the specified hit location.
  */
-skb_text_position_t skb_layout_hit_test(const skb_layout_t* layout, skb_movement_type_t type, float hit_x, float hit_y);
+SKB_API skb_text_position_t skb_layout_hit_test(const skb_layout_t* layout, skb_movement_type_t type, float hit_x, float hit_y);
 
 
 /** Struct identifying run of content. */
@@ -772,7 +772,7 @@ typedef struct skb_layout_content_hit_t {
  * @param hit_x hit X location
  * @return struct representing the content under the hit location.
  */
-skb_layout_content_hit_t skb_layout_hit_test_content_at_line(const skb_layout_t* layout, int32_t line_idx, float hit_x);
+SKB_API skb_layout_content_hit_t skb_layout_hit_test_content_at_line(const skb_layout_t* layout, int32_t line_idx, float hit_x);
 
 /**
  * Returns data identifying the content under the hit location.
@@ -782,7 +782,7 @@ skb_layout_content_hit_t skb_layout_hit_test_content_at_line(const skb_layout_t*
  * @param hit_y hit Y location
  * @return struct representing the content under the hit location.
  */
-skb_layout_content_hit_t skb_layout_hit_test_content(const skb_layout_t* layout, float hit_x, float hit_y);
+SKB_API skb_layout_content_hit_t skb_layout_hit_test_content(const skb_layout_t* layout, float hit_x, float hit_y);
 
 /**
  * Signature of content bounds getter callback.
@@ -804,7 +804,7 @@ typedef void skb_content_rect_func_t(skb_rect2_t rect, int32_t layout_run_idx, i
  * @param callback callback to call on each rectangle.
  * @param context context passed to the callback.
  */
-void skb_layout_get_content_run_bounds_bounds_at_line_by_id(const skb_layout_t* layout, int32_t line_idx, intptr_t content_id, skb_content_rect_func_t* callback, void* context);
+SKB_API void skb_layout_get_content_run_bounds_bounds_at_line_by_id(const skb_layout_t* layout, int32_t line_idx, intptr_t content_id, skb_content_rect_func_t* callback, void* context);
 
 /**
  * Return set of rectangles that represent the specified content run in the layout.
@@ -815,7 +815,7 @@ void skb_layout_get_content_run_bounds_bounds_at_line_by_id(const skb_layout_t* 
  * @param callback callback to call on each rectangle.
  * @param context context passed to the callback.
  */
-void skb_layout_get_content_run_bounds_by_id(const skb_layout_t* layout, intptr_t content_id, skb_content_rect_func_t* callback, void* context);
+SKB_API void skb_layout_get_content_run_bounds_by_id(const skb_layout_t* layout, intptr_t content_id, skb_content_rect_func_t* callback, void* context);
 
 
 /**
@@ -825,7 +825,7 @@ void skb_layout_get_content_run_bounds_by_id(const skb_layout_t* layout, intptr_
  * @param pos text position to use.
  * @return caret info at text position.
  */
-skb_caret_info_t skb_layout_get_caret_info_at_line(const skb_layout_t* layout, int32_t line_idx, skb_text_position_t pos);
+SKB_API skb_caret_info_t skb_layout_get_caret_info_at_line(const skb_layout_t* layout, int32_t line_idx, skb_text_position_t pos);
 
 /**
  * Returns caret info at the text position.
@@ -833,31 +833,31 @@ skb_caret_info_t skb_layout_get_caret_info_at_line(const skb_layout_t* layout, i
  * @param pos text position to use.
  * @return caret info at text position.
  */
-skb_caret_info_t skb_layout_get_caret_info_at(const skb_layout_t* layout, skb_text_position_t pos);
+SKB_API skb_caret_info_t skb_layout_get_caret_info_at(const skb_layout_t* layout, skb_text_position_t pos);
 
 /** @return text position of nearest start of the line, starting from specified text position. */
-skb_text_position_t skb_layout_get_line_start_at(const skb_layout_t* layout, skb_text_position_t pos);
+SKB_API skb_text_position_t skb_layout_get_line_start_at(const skb_layout_t* layout, skb_text_position_t pos);
 
 /** @return text position of nearest end of the line, starting from specified text position. */
-skb_text_position_t skb_layout_get_line_end_at(const skb_layout_t* layout, skb_text_position_t pos);
+SKB_API skb_text_position_t skb_layout_get_line_end_at(const skb_layout_t* layout, skb_text_position_t pos);
 
 /** @return text position of nearest start of a word, starting from specified text position. */
-skb_text_position_t skb_layout_get_word_start_at(const skb_layout_t* layout, skb_text_position_t pos);
+SKB_API skb_text_position_t skb_layout_get_word_start_at(const skb_layout_t* layout, skb_text_position_t pos);
 
 /** @return text position of nearest end of a word, starting from specified text position. */
-skb_text_position_t skb_layout_get_word_end_at(const skb_layout_t* layout, skb_text_position_t pos);
+SKB_API skb_text_position_t skb_layout_get_word_end_at(const skb_layout_t* layout, skb_text_position_t pos);
 
 /** @return text position of selection start, which is first in text order. */
-skb_text_position_t skb_layout_get_text_range_ordered_start(const skb_layout_t* layout, skb_text_range_t text_range);
+SKB_API skb_text_position_t skb_layout_get_text_range_ordered_start(const skb_layout_t* layout, skb_text_range_t text_range);
 
 /** @return text position of selection end, which is last in text order. */
-skb_text_position_t skb_layout_get_text_range_ordered_end(const skb_layout_t* layout, skb_text_range_t text_range);
+SKB_API skb_text_position_t skb_layout_get_text_range_ordered_end(const skb_layout_t* layout, skb_text_range_t text_range);
 
 /** @return ordered range of text (codepoints) representing the selection. End exclusive. */
-skb_range_t skb_layout_get_offset_range_from_text_range(const skb_layout_t* layout, skb_text_range_t text_range);
+SKB_API skb_range_t skb_layout_get_offset_range_from_text_range(const skb_layout_t* layout, skb_text_range_t text_range);
 
 /** @return number of codepoints in the selection. */
-int32_t skb_layout_get_text_range_count(const skb_layout_t* layout, skb_text_range_t text_range);
+SKB_API int32_t skb_layout_get_text_range_count(const skb_layout_t* layout, skb_text_range_t text_range);
 
 /**
  * Signature of text range bounds getter callback.
@@ -874,7 +874,7 @@ typedef void skb_text_range_bounds_func_t(skb_rect2_t rect, void* context);
  * @param callback callback to call on each rectangle
  * @param context context passed to the callback.
  */
-void skb_layout_iterate_text_range_bounds(const skb_layout_t* layout, skb_text_range_t text_range, skb_text_range_bounds_func_t* callback, void* context);
+SKB_API void skb_layout_iterate_text_range_bounds(const skb_layout_t* layout, skb_text_range_t text_range, skb_text_range_bounds_func_t* callback, void* context);
 
 /**
  * Iterates over set of bounding rectangles that represent the text range.
@@ -885,7 +885,7 @@ void skb_layout_iterate_text_range_bounds(const skb_layout_t* layout, skb_text_r
  * @param callback callback to call on each rectangle
  * @param context context passed to the callback.
  */
-void skb_layout_iterate_text_range_bounds_with_offset(const skb_layout_t* layout, skb_vec2_t offset, skb_text_range_t text_range, skb_text_range_bounds_func_t* callback, void* context);
+SKB_API void skb_layout_iterate_text_range_bounds_with_offset(const skb_layout_t* layout, skb_vec2_t offset, skb_text_range_t text_range, skb_text_range_bounds_func_t* callback, void* context);
 
 /** Struct describing how to draw indent decoration bars */
 typedef struct skb_layout_indent_decoration_info_t {
@@ -908,7 +908,7 @@ typedef struct skb_layout_indent_decoration_info_t {
  * @param layout layout to use.
  * @return indent decoration info.
  */
-skb_layout_indent_decoration_info_t skb_layout_get_indent_decoration_info(const skb_layout_t* layout);
+SKB_API skb_layout_indent_decoration_info_t skb_layout_get_indent_decoration_info(const skb_layout_t* layout);
 
 //
 // Caret iterator
@@ -964,7 +964,7 @@ typedef struct skb_caret_iterator_t {
  * @param line_idx index of the line to iterate.
  * @return initialized caret iterator.
  */
-skb_caret_iterator_t skb_caret_iterator_make(const skb_layout_t* layout, int32_t line_idx);
+SKB_API skb_caret_iterator_t skb_caret_iterator_make(const skb_layout_t* layout, int32_t line_idx);
 
 /**
  * Advances to the next caret location.
@@ -976,21 +976,21 @@ skb_caret_iterator_t skb_caret_iterator_make(const skb_layout_t* layout, int32_t
  * @param right iterator result on right grapheme.
  * @return true as long as the output values are valid.
  */
-bool skb_caret_iterator_next(skb_caret_iterator_t* iter, float* x, float* advance, float* mid_point, skb_caret_iterator_result_t* left, skb_caret_iterator_result_t* right);
+SKB_API bool skb_caret_iterator_next(skb_caret_iterator_t* iter, float* x, float* advance, float* mid_point, skb_caret_iterator_result_t* left, skb_caret_iterator_result_t* right);
 
 /**
  * Returns four-letter ISO 15924 script tag of the specified script.
  * @param script scrip to covert.
  * @return four letter tag.
  */
-uint32_t skb_script_to_iso15924_tag(uint8_t script);
+SKB_API uint32_t skb_script_to_iso15924_tag(uint8_t script);
 
 /**
  * Returns script from four-letter ISO 15924 script tag.
  * @param script_tag ISO 15924 script tag scrip to covert.
  * @return script.
  */
-uint8_t skb_script_from_iso15924_tag(uint32_t script_tag);
+SKB_API uint8_t skb_script_from_iso15924_tag(uint32_t script_tag);
 
 /** @} */
 

--- a/include/skb_layout_cache.h
+++ b/include/skb_layout_cache.h
@@ -30,13 +30,13 @@ typedef struct skb_layout_cache_t skb_layout_cache_t;
  * Creates a new layout cache.
  * @return newly created cache.
  */
-skb_layout_cache_t* skb_layout_cache_create(void);
+SKB_API skb_layout_cache_t* skb_layout_cache_create(void);
 
 /**
  * Destroy a layout cache.
  * @param cache pointer to layout cache to destroy.
  */
-void skb_layout_cache_destroy(skb_layout_cache_t* cache);
+SKB_API void skb_layout_cache_destroy(skb_layout_cache_t* cache);
 
 /**
  * Layouts specified text, or returns existing layout from cache if one exists.
@@ -48,7 +48,7 @@ void skb_layout_cache_destroy(skb_layout_cache_t* cache);
  * @param attributes attributes to apply to the text.
  * @return const pointer to the requested layout.
  */
-const skb_layout_t* skb_layout_cache_get_utf8(
+SKB_API const skb_layout_t* skb_layout_cache_get_utf8(
 	skb_layout_cache_t* cache, skb_temp_alloc_t* temp_alloc,
 	const skb_layout_params_t* params, const char* text, int32_t text_count, skb_attribute_set_t attributes);
 
@@ -62,7 +62,7 @@ const skb_layout_t* skb_layout_cache_get_utf8(
  * @param attributes attributes to apply to the text.
  * @return const pointer to the requested layout.
  */
-const skb_layout_t* skb_layout_cache_get_utf32(
+SKB_API const skb_layout_t* skb_layout_cache_get_utf32(
 	skb_layout_cache_t* cache, skb_temp_alloc_t* temp_alloc,
 	const skb_layout_params_t* params, const uint32_t* text, int32_t text_count, skb_attribute_set_t attributes);
 
@@ -75,7 +75,7 @@ const skb_layout_t* skb_layout_cache_get_utf32(
  * @param runs_count number of runs in runs array.
  * @return const pointer to the requested layout.
  */
-const skb_layout_t* skb_layout_cache_get_from_runs(
+SKB_API const skb_layout_t* skb_layout_cache_get_from_runs(
 	skb_layout_cache_t* cache, skb_temp_alloc_t* temp_alloc,
 	const skb_layout_params_t* params, const skb_content_run_t* runs, int32_t runs_count);
 
@@ -85,7 +85,7 @@ const skb_layout_t* skb_layout_cache_get_from_runs(
  * @param cache layout cache to compect
  * @return true if layouts were evicted.
  */
-bool skb_layout_cache_compact(skb_layout_cache_t* cache);
+SKB_API bool skb_layout_cache_compact(skb_layout_cache_t* cache);
 
 /** @} */
 

--- a/include/skb_rasterizer.h
+++ b/include/skb_rasterizer.h
@@ -58,26 +58,26 @@ typedef enum {
  * @param config pointer to rasterizer configuration.
  * @return pointer to the created rasterizer.
  */
-skb_rasterizer_t* skb_rasterizer_create(skb_rasterizer_config_t* config);
+SKB_API skb_rasterizer_t* skb_rasterizer_create(skb_rasterizer_config_t* config);
 
 /**
  * Returns default values for the rasterizer config. Can be used if you only want to modify a specific value.
  * @return default config.
  */
-skb_rasterizer_config_t skb_rasterizer_get_default_config(void);
+SKB_API skb_rasterizer_config_t skb_rasterizer_get_default_config(void);
 
 /**
  * Returns the config the rasterizer was initialized with.
  * @param rasterizer pointer to the rasterizer
  * @return config for the specified rasterizer.
  */
-skb_rasterizer_config_t skb_rasterizer_get_config(const skb_rasterizer_t* rasterizer);
+SKB_API skb_rasterizer_config_t skb_rasterizer_get_config(const skb_rasterizer_t* rasterizer);
 
 /**
  * Destroys a rasterizer previously created using skb_rasterizer_create().
  * @param rasterizer pointer to the rasterizer.
  */
-void skb_rasterizer_destroy(skb_rasterizer_t* rasterizer);
+SKB_API void skb_rasterizer_destroy(skb_rasterizer_t* rasterizer);
 
 /**
  * Calculates the dimensions required to rasterize a specific glyph at spcified size.
@@ -88,7 +88,7 @@ void skb_rasterizer_destroy(skb_rasterizer_t* rasterizer);
  * @param padding padding to leave around the glyph.
  * @return rect describing size and offset required to rasterize the glyph.
  */
-skb_rect2i_t skb_rasterizer_get_glyph_dimensions(uint32_t glyph_id, const skb_font_t* font, float font_size, int32_t padding);
+SKB_API skb_rect2i_t skb_rasterizer_get_glyph_dimensions(uint32_t glyph_id, const skb_font_t* font, float font_size, int32_t padding);
 
 /**
  * Rasterizes a glyph as alpha mask.
@@ -104,7 +104,7 @@ skb_rect2i_t skb_rasterizer_get_glyph_dimensions(uint32_t glyph_id, const skb_fo
  * @param target target image to rasterize to. The image must be 1 byte-per-pixel.
  * @return true of the rasterization succeeded.
  */
-bool skb_rasterizer_draw_alpha_glyph(
+SKB_API bool skb_rasterizer_draw_alpha_glyph(
 	skb_rasterizer_t* rasterizer, skb_temp_alloc_t* temp_alloc,
 	uint32_t glyph_id, const skb_font_t* font, float font_size, skb_rasterize_alpha_mode_t alpha_mode,
 	float offset_x, float offset_y, skb_image_t* target);
@@ -123,7 +123,7 @@ bool skb_rasterizer_draw_alpha_glyph(
  * @param target target image to rasterize to. The image must be 4 bytes-per-pixel.
  * @return true of the rasterization succeeded.
  */
-bool skb_rasterizer_draw_color_glyph(
+SKB_API bool skb_rasterizer_draw_color_glyph(
 	skb_rasterizer_t* rasterizer, skb_temp_alloc_t* temp_alloc,
 	uint32_t glyph_id, const skb_font_t* font, float font_size, skb_rasterize_alpha_mode_t alpha_mode,
 	int32_t offset_x, int32_t offset_y, skb_image_t* target);
@@ -136,7 +136,7 @@ bool skb_rasterizer_draw_color_glyph(
  * @param padding padding to leave around the icon.
  * @return rect describing size and offset required to rasterize the icon.
  */
-skb_rect2i_t skb_rasterizer_get_icon_dimensions(const skb_icon_t* icon, skb_vec2_t icon_scale, int32_t padding);
+SKB_API skb_rect2i_t skb_rasterizer_get_icon_dimensions(const skb_icon_t* icon, skb_vec2_t icon_scale, int32_t padding);
 
 /**
  * Rasterizes an icon as alpha mask.
@@ -151,7 +151,7 @@ skb_rect2i_t skb_rasterizer_get_icon_dimensions(const skb_icon_t* icon, skb_vec2
  * @param target target image to draw to. The image must be 4 bytes-per-pixel.
  * @return true of the rasterization succeeded.
  */
-bool skb_rasterizer_draw_alpha_icon(
+SKB_API bool skb_rasterizer_draw_alpha_icon(
 	skb_rasterizer_t* rasterizer, skb_temp_alloc_t* temp_alloc,
 	const skb_icon_t* icon, skb_vec2_t icon_scale, skb_rasterize_alpha_mode_t alpha_mode,
 	int32_t offset_x, int32_t offset_y, skb_image_t* target);
@@ -169,7 +169,7 @@ bool skb_rasterizer_draw_alpha_icon(
  * @param target target image to draw to. The image must be 4 bytes-per-pixel.
  * @return true of the rasterization succeeded.
  */
-bool skb_rasterizer_draw_color_icon(
+SKB_API bool skb_rasterizer_draw_color_icon(
 	skb_rasterizer_t* rasterizer, skb_temp_alloc_t* temp_alloc,
 	const skb_icon_t* icon, skb_vec2_t icon_scale, skb_rasterize_alpha_mode_t alpha_mode,
 	int32_t offset_x, int32_t offset_y, skb_image_t* target);
@@ -182,7 +182,7 @@ bool skb_rasterizer_draw_color_icon(
  * @param thickness thickness of the decoration line.
  * @return size of the pattern.
  */
-skb_vec2_t skb_rasterizer_get_decoration_pattern_size(skb_decoration_style_t style, float thickness);
+SKB_API skb_vec2_t skb_rasterizer_get_decoration_pattern_size(skb_decoration_style_t style, float thickness);
 
 /**
  * Calculates the dimensions of a canvas needed to rasterize specified pattern.
@@ -191,7 +191,7 @@ skb_vec2_t skb_rasterizer_get_decoration_pattern_size(skb_decoration_style_t sty
  * @param padding vertical padding to leave around the pattern. Note: horizontal padding is always 1, so that the pattern can be repeated horizontally.
  * @return rect describing size and offset required to rasterize the icon.
  */
-skb_rect2i_t skb_rasterizer_get_decoration_pattern_dimensions(skb_decoration_style_t style, float thickness, int32_t padding);
+SKB_API skb_rect2i_t skb_rasterizer_get_decoration_pattern_dimensions(skb_decoration_style_t style, float thickness, int32_t padding);
 
 /**
  * Rasterizes specified repeatable decoration pattern as alpha image.
@@ -206,7 +206,7 @@ skb_rect2i_t skb_rasterizer_get_decoration_pattern_dimensions(skb_decoration_sty
  * @param target target image to draw to. The image must be 1 bytes-per-pixel.
  * @return true of the rasterization succeeded.
  */
-bool skb_rasterizer_draw_decoration_pattern(
+SKB_API bool skb_rasterizer_draw_decoration_pattern(
 	skb_rasterizer_t* rasterizer, skb_temp_alloc_t* temp_alloc,
 	skb_decoration_style_t style, float thickness, skb_rasterize_alpha_mode_t alpha_mode,
 	int32_t offset_x, int32_t offset_y, skb_image_t* target);

--- a/include/skb_rich_layout.h
+++ b/include/skb_rich_layout.h
@@ -29,41 +29,41 @@ typedef struct skb_rich_layout_t skb_rich_layout_t;
  * Creates a new empty rich layout.
  * @return
  */
-skb_rich_layout_t* skb_rich_layout_create(void);
+SKB_API skb_rich_layout_t* skb_rich_layout_create(void);
 
 /**
  * Destroys and frees existing rich layout.
  * @param rich_layout rich layout to destroy
  */
-void skb_rich_layout_destroy(skb_rich_layout_t* rich_layout);
+SKB_API void skb_rich_layout_destroy(skb_rich_layout_t* rich_layout);
 
 /**
  * Reset the rich layout to empty, keeping the allocated buffes.
  * @param rich_layout rich layout to reset
  */
-void skb_rich_layout_reset(skb_rich_layout_t* rich_layout);
+SKB_API void skb_rich_layout_reset(skb_rich_layout_t* rich_layout);
 
 
 /** @returns numner of paragraphs in the rich layout */
-int32_t skb_rich_layout_get_paragraphs_count(const skb_rich_layout_t* rich_layout);
+SKB_API int32_t skb_rich_layout_get_paragraphs_count(const skb_rich_layout_t* rich_layout);
 
 /** @returns const pointer to the layout for specified paragraph. */
-const skb_layout_t* skb_rich_layout_get_layout(const skb_rich_layout_t* rich_layout, int32_t paragraph_idx);
+SKB_API const skb_layout_t* skb_rich_layout_get_layout(const skb_rich_layout_t* rich_layout, int32_t paragraph_idx);
 
 /** @returns rendering offset of the layout of specified paragraph */
-skb_vec2_t skb_rich_layout_get_layout_offset(const skb_rich_layout_t* rich_layout, int32_t paragraph_idx);
+SKB_API skb_vec2_t skb_rich_layout_get_layout_offset(const skb_rich_layout_t* rich_layout, int32_t paragraph_idx);
 
 /** @retruns the Y advance to next paragraphs of specified paragraph. */
-float skb_rich_layout_get_layout_advance_y(const skb_rich_layout_t* rich_layout, int32_t paragraph_idx);
+SKB_API float skb_rich_layout_get_layout_advance_y(const skb_rich_layout_t* rich_layout, int32_t paragraph_idx);
 
 /** @returns the text direction of specified paragraph */
-skb_text_direction_t skb_rich_layout_get_direction(const skb_rich_layout_t* rich_layout, int32_t paragraph_idx);
+SKB_API skb_text_direction_t skb_rich_layout_get_direction(const skb_rich_layout_t* rich_layout, int32_t paragraph_idx);
 
 /** @returns layout parameters of rich layout. */
-const skb_layout_params_t* skb_rich_layout_get_params(const skb_rich_layout_t* rich_layout);
+SKB_API const skb_layout_params_t* skb_rich_layout_get_params(const skb_rich_layout_t* rich_layout);
 
 /** @returns the bounds of the whole rich layout. */
-skb_rect2_t skb_rich_layout_get_bounds(const skb_rich_layout_t* rich_layout);
+SKB_API skb_rect2_t skb_rich_layout_get_bounds(const skb_rich_layout_t* rich_layout);
 
 /**
  * Updates the rich layout to from rich text.
@@ -82,7 +82,7 @@ skb_rect2_t skb_rich_layout_get_bounds(const skb_rich_layout_t* rich_layout);
  * @param composition_text_offset offset of the composition (IME) text, 0 if not used.
  * @param composition_text the composition text to insert at composition_text_offset, NULL if not used.
  */
-void skb_rich_layout_set_from_rich_text(
+SKB_API void skb_rich_layout_set_from_rich_text(
 	skb_rich_layout_t* rich_layout, skb_temp_alloc_t* temp_alloc,
 	const skb_layout_params_t* params, const skb_rich_text_t* rich_text,
 	int32_t composition_text_offset, const skb_text_t* composition_text);
@@ -94,7 +94,7 @@ void skb_rich_layout_set_from_rich_text(
  * @param rich_layout rich layout to update.
  * @param change change to apply.
  */
-void skb_rich_layout_apply_change(skb_rich_layout_t* rich_layout, skb_rich_text_change_t change);
+SKB_API void skb_rich_layout_apply_change(skb_rich_layout_t* rich_layout, skb_rich_text_change_t change);
 
 /**
  * Returns caret info at the text position.
@@ -102,7 +102,7 @@ void skb_rich_layout_apply_change(skb_rich_layout_t* rich_layout, skb_rich_text_
  * @param text_pos text postion to query
  * @return caret info at text position.
  */
-skb_caret_info_t skb_rich_layout_get_caret_info_at(const skb_rich_layout_t* rich_layout, skb_text_position_t text_pos);
+SKB_API skb_caret_info_t skb_rich_layout_get_caret_info_at(const skb_rich_layout_t* rich_layout, skb_text_position_t text_pos);
 
 /**
  * Iterates over set of bounding rectangles that represent the text range.
@@ -112,7 +112,7 @@ skb_caret_info_t skb_rich_layout_get_caret_info_at(const skb_rich_layout_t* rich
  * @param callback callback to call on each rectangle
  * @param context context passed to the callback.
  */
-void skb_rich_layout_get_text_range_bounds(const skb_rich_layout_t* rich_layout, skb_text_range_t text_range, skb_text_range_bounds_func_t* callback, void* context);
+SKB_API void skb_rich_layout_get_text_range_bounds(const skb_rich_layout_t* rich_layout, skb_text_range_t text_range, skb_text_range_bounds_func_t* callback, void* context);
 
 /**
  * Returns caret text position under the hit location.
@@ -124,7 +124,7 @@ void skb_rich_layout_get_text_range_bounds(const skb_rich_layout_t* rich_layout,
  * @param hit_y hit Y location
  * @return caret text position under the specified hit location.
  */
-skb_text_position_t skb_rich_layout_hit_test(const skb_rich_layout_t* rich_layout, skb_movement_type_t type, float hit_x, float hit_y);
+SKB_API skb_text_position_t skb_rich_layout_hit_test(const skb_rich_layout_t* rich_layout, skb_movement_type_t type, float hit_x, float hit_y);
 
 
 /** @} */

--- a/include/skb_rich_text.h
+++ b/include/skb_rich_text.h
@@ -55,25 +55,25 @@ typedef struct skb_rich_text_change_t {
  * Creates new empty rich text. Use skb_rich_text_destroy() to destroy.
  * @return pointer to new rich text
  */
-skb_rich_text_t* skb_rich_text_create(void);
+SKB_API skb_rich_text_t* skb_rich_text_create(void);
 
 /**
  * Destroys and frees provided rich text.
  * @param rich_text pointer to rich text to destroy.
  */
-void skb_rich_text_destroy(skb_rich_text_t* rich_text);
+SKB_API void skb_rich_text_destroy(skb_rich_text_t* rich_text);
 
 /**
  * Reset provided rich text to empty state, keeping allocated buffers.
  * @param rich_text pointer to rich text to reset.
  */
-void skb_rich_text_reset(skb_rich_text_t* rich_text);
+SKB_API void skb_rich_text_reset(skb_rich_text_t* rich_text);
 
 /** @return number of utf-32 codepoints in the rich text. */
-int32_t skb_rich_text_get_utf32_count(const skb_rich_text_t* rich_text);
+SKB_API int32_t skb_rich_text_get_utf32_count(const skb_rich_text_t* rich_text);
 
 /** @return number of utf-8 codeunits in the rich text in given range. */
-int32_t skb_rich_text_get_utf8_count_in_range(const skb_rich_text_t* rich_text, skb_text_range_t text_range);
+SKB_API int32_t skb_rich_text_get_utf8_count_in_range(const skb_rich_text_t* rich_text, skb_text_range_t text_range);
 
 /**
  * Returns text in given range as utf-8.
@@ -83,10 +83,10 @@ int32_t skb_rich_text_get_utf8_count_in_range(const skb_rich_text_t* rich_text, 
  * @param utf8_cap capacity if the utf-8 result string
  * @return number of utf-8 codeunits written.
  */
-int32_t skb_rich_text_get_utf8_in_range(const skb_rich_text_t* rich_text, skb_text_range_t text_range, char* utf8, int32_t utf8_cap);
+SKB_API int32_t skb_rich_text_get_utf8_in_range(const skb_rich_text_t* rich_text, skb_text_range_t text_range, char* utf8, int32_t utf8_cap);
 
 /** @return number of utf-32 codepoints in the rich text in given range. */
-int32_t skb_rich_text_get_utf32_count_in_range(const skb_rich_text_t* rich_text, skb_text_range_t text_range);
+SKB_API int32_t skb_rich_text_get_utf32_count_in_range(const skb_rich_text_t* rich_text, skb_text_range_t text_range);
 
 /**
  * Returns text in given range as utf-32.
@@ -96,28 +96,28 @@ int32_t skb_rich_text_get_utf32_count_in_range(const skb_rich_text_t* rich_text,
  * @param utf32_cap capacity if the utf-32 result string
  * @return number of utf-32 codepoints written.
  */
-int32_t skb_rich_text_get_utf32_in_range(const skb_rich_text_t* rich_text, skb_text_range_t text_range, uint32_t* utf32, int32_t utf32_cap);
+SKB_API int32_t skb_rich_text_get_utf32_in_range(const skb_rich_text_t* rich_text, skb_text_range_t text_range, uint32_t* utf32, int32_t utf32_cap);
 
 /** @returns the range of paragraphs the text range represents.*/
-skb_range_t skb_rich_text_get_paragraphs_range_from_text_range(skb_rich_text_t* rich_text, skb_text_range_t text_range);
+SKB_API skb_range_t skb_rich_text_get_paragraphs_range_from_text_range(skb_rich_text_t* rich_text, skb_text_range_t text_range);
 
 /** @return number of paragraphs in the rich text. */
-int32_t skb_rich_text_get_paragraphs_count(const skb_rich_text_t* rich_text);
+SKB_API int32_t skb_rich_text_get_paragraphs_count(const skb_rich_text_t* rich_text);
 
 /** @return const pointer to the text of specified paragraph. */
-const skb_text_t* skb_rich_text_get_paragraph_text(const skb_rich_text_t* rich_text, int32_t paragraph_idx);
+SKB_API const skb_text_t* skb_rich_text_get_paragraph_text(const skb_rich_text_t* rich_text, int32_t paragraph_idx);
 
 /** @return paragraph attributes associated with specified paragraph. */
-skb_attribute_set_t skb_rich_text_get_paragraph_attributes(const skb_rich_text_t* rich_text, int32_t paragraph_idx);
+SKB_API skb_attribute_set_t skb_rich_text_get_paragraph_attributes(const skb_rich_text_t* rich_text, int32_t paragraph_idx);
 
 /** @return number of utf-32 codepoints in specified paragraph. */
-int32_t skb_rich_text_get_paragraph_text_utf32_count(const skb_rich_text_t* rich_text, int32_t paragraph_idx);
+SKB_API int32_t skb_rich_text_get_paragraph_text_utf32_count(const skb_rich_text_t* rich_text, int32_t paragraph_idx);
 
 /** @return global text offset of specified paragraph. */
-int32_t skb_rich_text_get_paragraph_text_offset(const skb_rich_text_t* text, int32_t paragraph_idx);
+SKB_API int32_t skb_rich_text_get_paragraph_text_offset(const skb_rich_text_t* text, int32_t paragraph_idx);
 
 /** @return version of the specified paragraph. The version is updated on each change can can used to externally react to changes. */
-uint32_t skb_rich_text_get_paragraph_version(const skb_rich_text_t* rich_text, int32_t paragraph_idx);
+SKB_API uint32_t skb_rich_text_get_paragraph_version(const skb_rich_text_t* rich_text, int32_t paragraph_idx);
 
 
 /**
@@ -126,7 +126,7 @@ uint32_t skb_rich_text_get_paragraph_version(const skb_rich_text_t* rich_text, i
  * @param source_rich_text source rich text to append
  * @return info about changed paragraphs.
  */
-skb_rich_text_change_t skb_rich_text_append(skb_rich_text_t* rich_text, const skb_rich_text_t* source_rich_text);
+SKB_API skb_rich_text_change_t skb_rich_text_append(skb_rich_text_t* rich_text, const skb_rich_text_t* source_rich_text);
 
 /**
  * Appends range of text from another rich text.
@@ -135,7 +135,7 @@ skb_rich_text_change_t skb_rich_text_append(skb_rich_text_t* rich_text, const sk
  * @param source_text_range range of text in source to append
  * @return info about changed paragraphs.
  */
-skb_rich_text_change_t skb_rich_text_append_range(skb_rich_text_t* rich_text, const skb_rich_text_t* source_rich_text, skb_text_range_t source_text_range);
+SKB_API skb_rich_text_change_t skb_rich_text_append_range(skb_rich_text_t* rich_text, const skb_rich_text_t* source_rich_text, skb_text_range_t source_text_range);
 
 /**
  * Appends new empty paragraph.
@@ -143,7 +143,7 @@ skb_rich_text_change_t skb_rich_text_append_range(skb_rich_text_t* rich_text, co
  * @param paragraph_attributes attributes for the new paragraph.
  * @return info about changed paragraphs.
  */
-skb_rich_text_change_t skb_rich_text_append_paragraph(skb_rich_text_t* rich_text, skb_attribute_set_t paragraph_attributes);
+SKB_API skb_rich_text_change_t skb_rich_text_append_paragraph(skb_rich_text_t* rich_text, skb_attribute_set_t paragraph_attributes);
 
 /**
  * Appends text.
@@ -152,7 +152,7 @@ skb_rich_text_change_t skb_rich_text_append_paragraph(skb_rich_text_t* rich_text
  * @param source_text source text to append
  * @return info about changed paragraphs.
  */
-skb_rich_text_change_t skb_rich_text_append_text(skb_rich_text_t* rich_text, skb_temp_alloc_t* temp_alloc, const skb_text_t* source_text);
+SKB_API skb_rich_text_change_t skb_rich_text_append_text(skb_rich_text_t* rich_text, skb_temp_alloc_t* temp_alloc, const skb_text_t* source_text);
 
 /**
  * Appends range of text from text.
@@ -162,7 +162,7 @@ skb_rich_text_change_t skb_rich_text_append_text(skb_rich_text_t* rich_text, skb
  * @param source_text_range range of text in source to append
  * @return info about changed paragraphs.
  */
-skb_rich_text_change_t skb_rich_text_append_text_range(
+SKB_API skb_rich_text_change_t skb_rich_text_append_text_range(
 	skb_rich_text_t* rich_text, skb_temp_alloc_t* temp_alloc,
 	const skb_text_t* source_text, skb_text_range_t source_text_range);
 
@@ -175,7 +175,7 @@ skb_rich_text_change_t skb_rich_text_append_text_range(
  * @param attributes attributes to apply for appended text.
  * @return info about changed paragraphs.
  */
-skb_rich_text_change_t skb_rich_text_append_utf8(
+SKB_API skb_rich_text_change_t skb_rich_text_append_utf8(
 	skb_rich_text_t* rich_text, skb_temp_alloc_t* temp_alloc,
 	const char* utf8, int32_t utf8_count, skb_attribute_set_t attributes);
 
@@ -190,7 +190,7 @@ skb_rich_text_change_t skb_rich_text_append_utf8(
  * @param payload payload to attach to the text.
  * @return info about changed paragraphs.
  */
-skb_rich_text_change_t skb_rich_text_append_utf8_with_payload(
+SKB_API skb_rich_text_change_t skb_rich_text_append_utf8_with_payload(
 	skb_rich_text_t* rich_text, skb_temp_alloc_t* temp_alloc,
 	const char* utf8, int32_t utf8_count, skb_attribute_set_t attributes,
 	uint8_t span_flags, const skb_data_blob_t* payload);
@@ -204,7 +204,7 @@ skb_rich_text_change_t skb_rich_text_append_utf8_with_payload(
  * @param attributes attributes to apply for appended text.
  * @return info about changed paragraphs.
  */
-skb_rich_text_change_t skb_rich_text_append_utf32(
+SKB_API skb_rich_text_change_t skb_rich_text_append_utf32(
 	skb_rich_text_t* rich_text, skb_temp_alloc_t* temp_alloc,
 	const uint32_t* utf32, int32_t utf32_count, skb_attribute_set_t attributes);
 
@@ -219,7 +219,7 @@ skb_rich_text_change_t skb_rich_text_append_utf32(
  * @param payload payload to attach to the text.
  * @return info about changed paragraphs.
  */
-skb_rich_text_change_t skb_rich_text_append_utf32_with_payload(
+SKB_API skb_rich_text_change_t skb_rich_text_append_utf32_with_payload(
 	skb_rich_text_t* rich_text, skb_temp_alloc_t* temp_alloc,
 	const uint32_t* utf32, int32_t utf32_count, skb_attribute_set_t attributes,
 	uint8_t span_flags, const skb_data_blob_t* payload);
@@ -231,7 +231,7 @@ skb_rich_text_change_t skb_rich_text_append_utf32_with_payload(
  * @param source_rich_text source text to insert.
  * @return info about changed paragraphs.
  */
-skb_rich_text_change_t skb_rich_text_insert(skb_rich_text_t* rich_text, skb_text_range_t text_range, const skb_rich_text_t* source_rich_text);
+SKB_API skb_rich_text_change_t skb_rich_text_insert(skb_rich_text_t* rich_text, skb_text_range_t text_range, const skb_rich_text_t* source_rich_text);
 
 /**
  * Replaces specified text range with range of text in source rich text.
@@ -241,7 +241,7 @@ skb_rich_text_change_t skb_rich_text_insert(skb_rich_text_t* rich_text, skb_text
  * @param source_text_range source text range to insert.
  * @return info about changed paragraphs.
  */
-skb_rich_text_change_t skb_rich_text_insert_range(skb_rich_text_t* rich_text, skb_text_range_t text_range, const skb_rich_text_t* source_rich_text, skb_text_range_t source_text_range);
+SKB_API skb_rich_text_change_t skb_rich_text_insert_range(skb_rich_text_t* rich_text, skb_text_range_t text_range, const skb_rich_text_t* source_rich_text, skb_text_range_t source_text_range);
 
 /**
  * Removes specified range of text.
@@ -249,7 +249,7 @@ skb_rich_text_change_t skb_rich_text_insert_range(skb_rich_text_t* rich_text, sk
  * @param text_range text range to remove
  * @return info about changed paragraphs.
  */
-skb_rich_text_change_t skb_rich_text_remove(skb_rich_text_t* rich_text, skb_text_range_t text_range);
+SKB_API skb_rich_text_change_t skb_rich_text_remove(skb_rich_text_t* rich_text, skb_text_range_t text_range);
 
 
 /**
@@ -259,7 +259,7 @@ skb_rich_text_change_t skb_rich_text_remove(skb_rich_text_t* rich_text, skb_text
  * @param source_rich_text source rich text to copy from
  * @param source_text_range range of text to copy the attributes from
  */
-void skb_rich_text_copy_attributes_in_range(skb_rich_text_t* rich_text, const skb_rich_text_t* source_rich_text, skb_text_range_t source_text_range);
+SKB_API void skb_rich_text_copy_attributes_in_range(skb_rich_text_t* rich_text, const skb_rich_text_t* source_rich_text, skb_text_range_t source_text_range);
 
 /**
  * Replaces attributes in give range with attributes from source text.
@@ -269,7 +269,7 @@ void skb_rich_text_copy_attributes_in_range(skb_rich_text_t* rich_text, const sk
  * @param text_range text range to insert the attributes to
  * @param source_rich_text source rich text to copy the attributes from
  */
-void skb_rich_text_insert_attributes(skb_rich_text_t* rich_text, skb_text_range_t text_range, const skb_rich_text_t* source_rich_text);
+SKB_API void skb_rich_text_insert_attributes(skb_rich_text_t* rich_text, skb_text_range_t text_range, const skb_rich_text_t* source_rich_text);
 
 
 /**
@@ -278,7 +278,7 @@ void skb_rich_text_insert_attributes(skb_rich_text_t* rich_text, skb_text_range_
  * @param text_range text range representing the paragraphs to modify
  * @param attribute attribute to add
  */
-void skb_rich_text_set_paragraph_attribute(skb_rich_text_t* rich_text, skb_text_range_t text_range, skb_attribute_t attribute);
+SKB_API void skb_rich_text_set_paragraph_attribute(skb_rich_text_t* rich_text, skb_text_range_t text_range, skb_attribute_t attribute);
 
 /**
  * Sets paragraph attributes delta for all the paragraphs that intersect the text range.
@@ -287,7 +287,7 @@ void skb_rich_text_set_paragraph_attribute(skb_rich_text_t* rich_text, skb_text_
  * @param text_range text range representing the paragraphs to modify
  * @param attribute attribute delta to apply
  */
-void skb_rich_text_set_paragraph_attribute_delta(skb_rich_text_t* rich_text, skb_text_range_t text_range, skb_attribute_t attribute);
+SKB_API void skb_rich_text_set_paragraph_attribute_delta(skb_rich_text_t* rich_text, skb_text_range_t text_range, skb_attribute_t attribute);
 
 /**
  * Sets text attribute for given text range,
@@ -295,7 +295,7 @@ void skb_rich_text_set_paragraph_attribute_delta(skb_rich_text_t* rich_text, skb
  * @param text_range range of text to modify.
  * @param attribute attribute to set.
  */
-void skb_rich_text_set_attribute(skb_rich_text_t* rich_text, skb_text_range_t text_range, skb_attribute_t attribute);
+SKB_API void skb_rich_text_set_attribute(skb_rich_text_t* rich_text, skb_text_range_t text_range, skb_attribute_t attribute);
 
 /**
  * Sets text attribute for given text range,
@@ -305,7 +305,7 @@ void skb_rich_text_set_attribute(skb_rich_text_t* rich_text, skb_text_range_t te
  * @param span_flags span flags to apply for the text, see skb_attribute_span_flags_t.
  * @param payload payload to attach to the text range.
  */
-void skb_rich_text_set_attribute_with_payload(skb_rich_text_t* rich_text, skb_text_range_t text_range, skb_attribute_t attribute, uint8_t span_flags, const skb_data_blob_t* payload);
+SKB_API void skb_rich_text_set_attribute_with_payload(skb_rich_text_t* rich_text, skb_text_range_t text_range, skb_attribute_t attribute, uint8_t span_flags, const skb_data_blob_t* payload);
 
 /**
  * Clears text attribute for given text range.
@@ -313,14 +313,14 @@ void skb_rich_text_set_attribute_with_payload(skb_rich_text_t* rich_text, skb_te
  * @param text_range range of text to modify.
  * @param attribute attribute to remove.
  */
-void skb_rich_text_clear_attribute(skb_rich_text_t* rich_text, skb_text_range_t text_range, skb_attribute_t attribute);
+SKB_API void skb_rich_text_clear_attribute(skb_rich_text_t* rich_text, skb_text_range_t text_range, skb_attribute_t attribute);
 
 /**
  * Clears all attributes from given text range.
  * @param rich_text richt text to modify.
  * @param text_range range of text to modify.
  */
-void skb_rich_text_clear_all_attributes(skb_rich_text_t* rich_text, skb_text_range_t text_range);
+SKB_API void skb_rich_text_clear_all_attributes(skb_rich_text_t* rich_text, skb_text_range_t text_range);
 
 /**
  * Returns if all of the specified range has the attribute.
@@ -329,7 +329,7 @@ void skb_rich_text_clear_all_attributes(skb_rich_text_t* rich_text, skb_text_ran
  * @param attribute attribute to match.
  * @return true if the whole specific range contains the attribute.
  */
-bool skb_rich_text_has_attribute(const skb_rich_text_t* rich_text, skb_text_range_t text_range, skb_attribute_t attribute);
+SKB_API bool skb_rich_text_has_attribute(const skb_rich_text_t* rich_text, skb_text_range_t text_range, skb_attribute_t attribute);
 
 /**
  * Returns attributes that are applied to all of the specified range.
@@ -340,7 +340,7 @@ bool skb_rich_text_has_attribute(const skb_rich_text_t* rich_text, skb_text_rang
  * @param attributes_cap capacity of the results array.
  * @return number of attributes stored in attributes array.
  */
-int32_t skb_rich_text_get_attributes(const skb_rich_text_t* rich_text, skb_text_range_t text_range, uint32_t attribute_kind, skb_attribute_t* attributes, int32_t attributes_cap);
+SKB_API int32_t skb_rich_text_get_attributes(const skb_rich_text_t* rich_text, skb_text_range_t text_range, uint32_t attribute_kind, skb_attribute_t* attributes, int32_t attributes_cap);
 
 /**
  * Returns the whole of the attribute that is applied to specified range.
@@ -349,7 +349,7 @@ int32_t skb_rich_text_get_attributes(const skb_rich_text_t* rich_text, skb_text_
  * @param attribute attribute to match.
  * @return text range the attribute is applied to or empty range if attribute not found.
  */
-skb_text_range_t skb_rich_text_get_attribute_text_range(const skb_rich_text_t* rich_text, skb_text_range_t text_range, skb_attribute_t attribute);
+SKB_API skb_text_range_t skb_rich_text_get_attribute_text_range(const skb_rich_text_t* rich_text, skb_text_range_t text_range, skb_attribute_t attribute);
 
 /**
  * Returns the payload of the attribute that is applied to specified range.
@@ -358,7 +358,7 @@ skb_text_range_t skb_rich_text_get_attribute_text_range(const skb_rich_text_t* r
  * @param attribute attribute to match.
  * @return pointer to the payload applied to the attribute, or NULL if attribute not found.
  */
-skb_data_blob_t* skb_rich_text_get_attribute_payload(const skb_rich_text_t* rich_text, skb_text_range_t text_range, skb_attribute_t attribute);
+SKB_API skb_data_blob_t* skb_rich_text_get_attribute_payload(const skb_rich_text_t* rich_text, skb_text_range_t text_range, skb_attribute_t attribute);
 
 /**
  * Signature of text remove callback.
@@ -376,7 +376,7 @@ typedef bool skb_rich_text_remove_func_t(uint32_t codepoint, int32_t paragraph_i
  * @param filter_func filter function used as predicate to check if a codepoint should be removed.
  * @param context context pointer passed to the filter function.
  */
-void skb_rich_text_remove_if(skb_rich_text_t* rich_text, skb_rich_text_remove_func_t* filter_func, void* context);
+SKB_API void skb_rich_text_remove_if(skb_rich_text_t* rich_text, skb_rich_text_remove_func_t* filter_func, void* context);
 
 /**
  * Returns paragraph position from text position.
@@ -385,7 +385,7 @@ void skb_rich_text_remove_if(skb_rich_text_t* rich_text, skb_rich_text_remove_fu
  * @param affinity_usage if SKB_AFFINITY_USE the text affinity is applied when converting text position to text offset.
  * @return paragraph position corresponding the specified text position.
  */
-skb_paragraph_position_t skb_rich_text_get_paragraph_position_from_text_position(const skb_rich_text_t* rich_text, skb_text_position_t text_pos, skb_affinity_usage_t affinity_usage);
+SKB_API skb_paragraph_position_t skb_rich_text_get_paragraph_position_from_text_position(const skb_rich_text_t* rich_text, skb_text_position_t text_pos, skb_affinity_usage_t affinity_usage);
 
 /**
  * Returns paragraph range from text range.
@@ -394,13 +394,13 @@ skb_paragraph_position_t skb_rich_text_get_paragraph_position_from_text_position
  * @param affinity_usage if SKB_AFFINITY_USE the text affinity is applied when converting text position to text offset.
  * @return paragraph range corresponding the specified text range.
  */
-skb_paragraph_range_t skb_rich_text_get_paragraph_range_from_text_range(const skb_rich_text_t* rich_text, skb_text_range_t text_range, skb_affinity_usage_t affinity_usage);
+SKB_API skb_paragraph_range_t skb_rich_text_get_paragraph_range_from_text_range(const skb_rich_text_t* rich_text, skb_text_range_t text_range, skb_affinity_usage_t affinity_usage);
 
 /** @returns text offset from text position. */
-int32_t skb_rich_text_get_offset_from_text_position(const skb_rich_text_t* rich_text, skb_text_position_t text_pos);
+SKB_API int32_t skb_rich_text_get_offset_from_text_position(const skb_rich_text_t* rich_text, skb_text_position_t text_pos);
 
 /** @returns text offset range from text range. */
-skb_range_t skb_rich_text_get_offset_range_from_text_range(const skb_rich_text_t* rich_text, skb_text_range_t text_range);
+SKB_API skb_range_t skb_rich_text_get_offset_range_from_text_range(const skb_rich_text_t* rich_text, skb_text_range_t text_range);
 
 /**
  * Get the start of the next grapheme in the rich text based on text position.
@@ -408,7 +408,7 @@ skb_range_t skb_rich_text_get_offset_range_from_text_range(const skb_rich_text_t
  * @param text_pos text position where to start looking.
  * @return text position of the start of the next grapheme.
  */
-skb_text_position_t skb_rich_text_get_next_grapheme_pos(const skb_rich_text_t* rich_text, skb_text_position_t text_pos);
+SKB_API skb_text_position_t skb_rich_text_get_next_grapheme_pos(const skb_rich_text_t* rich_text, skb_text_position_t text_pos);
 
 /**
  * Get the start of the previous grapheme in the rich text based on text position.
@@ -416,7 +416,7 @@ skb_text_position_t skb_rich_text_get_next_grapheme_pos(const skb_rich_text_t* r
  * @param text_pos text position where to start looking.
  * @return text position of the start of the previous grapheme.
  */
-skb_text_position_t skb_rich_text_get_prev_grapheme_pos(const skb_rich_text_t* rich_text, skb_text_position_t text_pos);
+SKB_API skb_text_position_t skb_rich_text_get_prev_grapheme_pos(const skb_rich_text_t* rich_text, skb_text_position_t text_pos);
 
 /**
  * Get the start of the current grapheme in the rich text based on text position.
@@ -424,7 +424,7 @@ skb_text_position_t skb_rich_text_get_prev_grapheme_pos(const skb_rich_text_t* r
  * @param text_pos text position where to start looking.
  * @return text position of the start of the current grapheme.
  */
-skb_text_position_t skb_rich_text_align_grapheme_pos(const skb_rich_text_t* rich_text, skb_text_position_t text_pos);
+SKB_API skb_text_position_t skb_rich_text_align_grapheme_pos(const skb_rich_text_t* rich_text, skb_text_position_t text_pos);
 
 /** @} */
 

--- a/include/skb_text.h
+++ b/include/skb_text.h
@@ -56,7 +56,7 @@ typedef struct skb_text_t skb_text_t;
  * Creates empty attributed text. Use skb_text_destroy() to destroy.
  * @return pointer to the newly created text.
  */
-skb_text_t* skb_text_create(void);
+SKB_API skb_text_t* skb_text_create(void);
 
 /**
  * Creates empty attributed text that uses the temp allocator. Use skb_text_destroy() to destroy.
@@ -64,19 +64,19 @@ skb_text_t* skb_text_create(void);
  * @param temp_alloc temp alloc to use with the text.
  * @return pointer to the newly created text.
  */
-skb_text_t* skb_text_create_temp(skb_temp_alloc_t* temp_alloc);
+SKB_API skb_text_t* skb_text_create_temp(skb_temp_alloc_t* temp_alloc);
 
 /**
  * Destroys specified text.
  * @param text text to destroy
  */
-void skb_text_destroy(skb_text_t* text);
+SKB_API void skb_text_destroy(skb_text_t* text);
 
 /**
  * Makes the text empty, but keeps the underlying buffers.
  * @param text text to reset.
  */
-void skb_text_reset(skb_text_t* text);
+SKB_API void skb_text_reset(skb_text_t* text);
 
 /**
  * Reserves memory in the text buffer for text and attributes. If larger buffer is already allocated, nothing changes.
@@ -84,20 +84,20 @@ void skb_text_reset(skb_text_t* text);
  * @param text_count reserved number of codepoints
  * @param spans_count reserved number of attribute spans.
  */
-void skb_text_reserve(skb_text_t* text, int32_t text_count, int32_t spans_count);
+SKB_API void skb_text_reserve(skb_text_t* text, int32_t text_count, int32_t spans_count);
 
 /** @return length of the text (utf-32 codeunits).  */
-int32_t skb_text_get_utf32_count(const skb_text_t* text);
+SKB_API int32_t skb_text_get_utf32_count(const skb_text_t* text);
 /** @return const pointer to the utf-32 string. */
-const uint32_t * skb_text_get_utf32(const skb_text_t* text);
+SKB_API const uint32_t * skb_text_get_utf32(const skb_text_t* text);
 /** @return const pointer to the text property flags (current supports only grapheme breaks) */
-const uint8_t* skb_text_get_props(const skb_text_t* text);
+SKB_API const uint8_t* skb_text_get_props(const skb_text_t* text);
 
 
 /** @return number of attribute spans of the text. */
-int32_t skb_text_get_attribute_spans_count(const skb_text_t* text);
+SKB_API int32_t skb_text_get_attribute_spans_count(const skb_text_t* text);
 /** @return const pointer to the attribute spans of the text. */
-const skb_attribute_span_t* skb_text_get_attribute_spans(const skb_text_t* text);
+SKB_API const skb_attribute_span_t* skb_text_get_attribute_spans(const skb_text_t* text);
 
 /**
  * Get the start of the next grapheme in the layout based on text offset.
@@ -105,7 +105,7 @@ const skb_attribute_span_t* skb_text_get_attribute_spans(const skb_text_t* text)
  * @param text_offset offset (codepoints) in the text where to start looking.
  * @return offset (codepoints) to the start of the next grapheme.
  */
-int32_t skb_text_get_next_grapheme_offset(const skb_text_t* text, int32_t text_offset);
+SKB_API int32_t skb_text_get_next_grapheme_offset(const skb_text_t* text, int32_t text_offset);
 
 /**
  * Get the start of the previous grapheme in the layout based on text offset.
@@ -113,7 +113,7 @@ int32_t skb_text_get_next_grapheme_offset(const skb_text_t* text, int32_t text_o
  * @param text_offset offset (codepoints) in the text where to start looking.
  * @return offset (codepoints) to the start of the previous grapheme.
  */
-int32_t skb_text_get_prev_grapheme_offset(const skb_text_t* text, int32_t text_offset);
+SKB_API int32_t skb_text_get_prev_grapheme_offset(const skb_text_t* text, int32_t text_offset);
 
 /**
  * Get the start of the current grapheme in the layout based on text offset.
@@ -121,7 +121,7 @@ int32_t skb_text_get_prev_grapheme_offset(const skb_text_t* text, int32_t text_o
  * @param text_offset offset (codepoints) in the text where to start looking.
  * @return offset (codepoints) to the start of the current grapheme.
  */
-int32_t skb_text_align_grapheme_offset(const skb_text_t* text, int32_t text_offset);
+SKB_API int32_t skb_text_align_grapheme_offset(const skb_text_t* text, int32_t text_offset);
 
 /**
  * Returns the text offset (codepoint) from specific text position, taking affinity into account.
@@ -129,17 +129,17 @@ int32_t skb_text_align_grapheme_offset(const skb_text_t* text, int32_t text_offs
  * @param pos position within the text.
  * @return text offset.
  */
-int32_t skb_text_get_offset_range_from_text_position(const skb_text_t* text, skb_text_position_t pos);
+SKB_API int32_t skb_text_get_offset_range_from_text_position(const skb_text_t* text, skb_text_position_t pos);
 
 /** @returns range that is validated against the text. */
-skb_range_t skb_text_get_range_from_text_range(const skb_text_t* rich_text, skb_text_range_t text_range);
+SKB_API skb_range_t skb_text_get_range_from_text_range(const skb_text_t* rich_text, skb_text_range_t text_range);
 
 /**
  * Appends the contents from other text.
  * @param text pointer to the text to modify
  * @param text_from text to copy from.
  */
-void skb_text_append(skb_text_t* text, const skb_text_t* text_from);
+SKB_API void skb_text_append(skb_text_t* text, const skb_text_t* text_from);
 
 /**
  * Appends range of contents from other text.
@@ -147,7 +147,7 @@ void skb_text_append(skb_text_t* text, const skb_text_t* text_from);
  * @param source_text text to copy from.
  * @param source_text_range text range to copy (in utf-32 codepoints).
  */
-void skb_text_append_range(skb_text_t* text, const skb_text_t* source_text, skb_text_range_t source_text_range);
+SKB_API void skb_text_append_range(skb_text_t* text, const skb_text_t* source_text, skb_text_range_t source_text_range);
 
 /**
  * Appends utf-8 string with attributes.
@@ -156,7 +156,7 @@ void skb_text_append_range(skb_text_t* text, const skb_text_t* source_text, skb_
  * @param utf8_count length of the utf-8 string, or -1 if the string is zero terminated.
  * @param attributes slice of attributes to apply to the appended text.
  */
-void skb_text_append_utf8(skb_text_t* text, const char* utf8, int32_t utf8_count, skb_attribute_set_t attributes);
+SKB_API void skb_text_append_utf8(skb_text_t* text, const char* utf8, int32_t utf8_count, skb_attribute_set_t attributes);
 
 /**
  * Appends utf-8 string with attributes and payload.
@@ -167,7 +167,7 @@ void skb_text_append_utf8(skb_text_t* text, const char* utf8, int32_t utf8_count
  * @param span_flags span flags to apply for all the attributes, see skb_attribute_span_flags_t.
  * @param payload payload to apply for all the attributes.
  */
-void skb_text_append_utf8_with_payload(skb_text_t* text, const char* utf8, int32_t utf8_count, skb_attribute_set_t attributes, uint8_t span_flags, const skb_data_blob_t* payload);
+SKB_API void skb_text_append_utf8_with_payload(skb_text_t* text, const char* utf8, int32_t utf8_count, skb_attribute_set_t attributes, uint8_t span_flags, const skb_data_blob_t* payload);
 
 /**
  * Appends utf-32 string with attributes.
@@ -176,7 +176,7 @@ void skb_text_append_utf8_with_payload(skb_text_t* text, const char* utf8, int32
  * @param utf32_count length of the utf-32 string, or -1 if the string is zero terminated.
  * @param attributes slice of attributes to apply to the appended text.
  */
-void skb_text_append_utf32(skb_text_t* text, const uint32_t* utf32, int32_t utf32_count, skb_attribute_set_t attributes);
+SKB_API void skb_text_append_utf32(skb_text_t* text, const uint32_t* utf32, int32_t utf32_count, skb_attribute_set_t attributes);
 
 /**
  * Appends utf-32 string with attributes and payload.
@@ -187,7 +187,7 @@ void skb_text_append_utf32(skb_text_t* text, const uint32_t* utf32, int32_t utf3
  * @param span_flags span flags to apply for all the attributes, see skb_attribute_span_flags_t.
  * @param payload payload to apply for all the attributes.
  */
-void skb_text_append_utf32_with_payload(skb_text_t* text, const uint32_t* utf32, int32_t utf32_count, skb_attribute_set_t attributes, uint8_t span_flags, const skb_data_blob_t* payload);
+SKB_API void skb_text_append_utf32_with_payload(skb_text_t* text, const uint32_t* utf32, int32_t utf32_count, skb_attribute_set_t attributes, uint8_t span_flags, const skb_data_blob_t* payload);
 
 /**
  * Inserts text replacing the text range.
@@ -195,7 +195,7 @@ void skb_text_append_utf32_with_payload(skb_text_t* text, const uint32_t* utf32,
  * @param text_range text range to replace (in utf-32 codepoints)
  * @param source_text text to insert.
  */
-void skb_text_insert(skb_text_t* text, skb_text_range_t text_range, const skb_text_t* source_text);
+SKB_API void skb_text_insert(skb_text_t* text, skb_text_range_t text_range, const skb_text_t* source_text);
 
 /**
  * Inserts utf-8 string replacing the text range.
@@ -205,7 +205,7 @@ void skb_text_insert(skb_text_t* text, skb_text_range_t text_range, const skb_te
  * @param utf8_count length of the utf-8 string, or -1 if the string is zero terminated.
  * @param attributes slice of attributes to apply to the inserted text.
  */
-void skb_text_insert_utf8(skb_text_t* text, skb_text_range_t text_range, const char* utf8, int32_t utf8_count, skb_attribute_set_t attributes);
+SKB_API void skb_text_insert_utf8(skb_text_t* text, skb_text_range_t text_range, const char* utf8, int32_t utf8_count, skb_attribute_set_t attributes);
 
 /**
  * Inserts utf-8 string and payload replacing the text range.
@@ -217,7 +217,7 @@ void skb_text_insert_utf8(skb_text_t* text, skb_text_range_t text_range, const c
  * @param span_flags span flags to apply for all the attributes, see skb_attribute_span_flags_t.
  * @param payload payload to apply for all the attributes.
  */
-void skb_text_insert_utf8_with_payload(skb_text_t* text, skb_text_range_t text_range, const char* utf8, int32_t utf8_count, skb_attribute_set_t attributes, uint8_t span_flags, const skb_data_blob_t* payload);
+SKB_API void skb_text_insert_utf8_with_payload(skb_text_t* text, skb_text_range_t text_range, const char* utf8, int32_t utf8_count, skb_attribute_set_t attributes, uint8_t span_flags, const skb_data_blob_t* payload);
 
 /**
  * Inserts utf-32 string replacing the text range.
@@ -227,7 +227,7 @@ void skb_text_insert_utf8_with_payload(skb_text_t* text, skb_text_range_t text_r
  * @param utf32_count length of the utf-32 string, or -1 if the string is zero terminated.
  * @param attributes slice of attributes to apply to the inserted text.
  */
-void skb_text_insert_utf32(skb_text_t* text, skb_text_range_t text_range, const uint32_t* utf32, int32_t utf32_count, skb_attribute_set_t attributes);
+SKB_API void skb_text_insert_utf32(skb_text_t* text, skb_text_range_t text_range, const uint32_t* utf32, int32_t utf32_count, skb_attribute_set_t attributes);
 
 /**
  * Inserts utf-32 string and payload replacing the text range.
@@ -239,14 +239,14 @@ void skb_text_insert_utf32(skb_text_t* text, skb_text_range_t text_range, const 
  * @param span_flags span flags to apply for all the attributes, see skb_attribute_span_flags_t.
  * @param payload payload to apply for all the attributes.
  */
-void skb_text_insert_utf32_with_payload(skb_text_t* text, skb_text_range_t text_range, const uint32_t* utf32, int32_t utf32_count, skb_attribute_set_t attributes, uint8_t span_flags, const skb_data_blob_t* payload);
+SKB_API void skb_text_insert_utf32_with_payload(skb_text_t* text, skb_text_range_t text_range, const uint32_t* utf32, int32_t utf32_count, skb_attribute_set_t attributes, uint8_t span_flags, const skb_data_blob_t* payload);
 
 /**
  * Removes range of text.
  * @param text pointer to the text to modify
  * @param text_range range of text and attributes (in utf-32 codepoints) to remove.
  */
-void skb_text_remove(skb_text_t* text, skb_text_range_t text_range);
+SKB_API void skb_text_remove(skb_text_t* text, skb_text_range_t text_range);
 
 /**
  * Signature of remove_if predicate.
@@ -263,7 +263,7 @@ typedef bool skb_text_remove_func_t(uint32_t codepoint, int32_t index, void* con
  * @param filter_func pointer to filter function.
  * @param context context pointer passed to filter functions.
  */
-void skb_text_remove_if(skb_text_t* text, skb_text_remove_func_t* filter_func, void* context);
+SKB_API void skb_text_remove_if(skb_text_t* text, skb_text_remove_func_t* filter_func, void* context);
 
 /**
  * Tries to find utf-32 string value in the text, and returns the matching range, or empty if not found.
@@ -273,7 +273,7 @@ void skb_text_remove_if(skb_text_t* text, skb_text_remove_func_t* filter_func, v
  * @param value_utf32_count length of the utf-32 string to find, or -1 is zero terminated.
  * @return range of text matching the specfied value, or empty range if value not found.
  */
-skb_text_range_t skb_text_find_reverse_utf32(const skb_text_t* text, skb_text_range_t search_text_range, const uint32_t* value_utf32, int32_t value_utf32_count);
+SKB_API skb_text_range_t skb_text_find_reverse_utf32(const skb_text_t* text, skb_text_range_t search_text_range, const uint32_t* value_utf32, int32_t value_utf32_count);
 
 
 /**
@@ -283,7 +283,7 @@ skb_text_range_t skb_text_find_reverse_utf32(const skb_text_t* text, skb_text_ra
  * @param from_text text to copy the attributes to.
  * @param from_text_range range on from_text where to copy the attributes.
  */
-void skb_text_copy_attributes_range(skb_text_t* text, const skb_text_t* from_text, skb_text_range_t from_text_range);
+SKB_API void skb_text_copy_attributes_range(skb_text_t* text, const skb_text_t* from_text, skb_text_range_t from_text_range);
 
 /**
  * Replaces attributes in text in specified range with attributes from from_text.
@@ -292,7 +292,7 @@ void skb_text_copy_attributes_range(skb_text_t* text, const skb_text_t* from_tex
  * @param text_range range of text to replace
  * @param from_text text to copy the properties from
  */
-void skb_text_insert_attributes(skb_text_t* text, skb_text_range_t text_range, const skb_text_t* from_text);
+SKB_API void skb_text_insert_attributes(skb_text_t* text, skb_text_range_t text_range, const skb_text_t* from_text);
 
 /**
  * Clears attribute of specific type from specified range.
@@ -300,14 +300,14 @@ void skb_text_insert_attributes(skb_text_t* text, skb_text_range_t text_range, c
  * @param text_range text range of attributes to remove (in utf-32 codepoints)
  * @param attribute attribute to remove.
  */
-void skb_text_clear_attribute(skb_text_t* text, skb_text_range_t text_range, skb_attribute_t attribute);
+SKB_API void skb_text_clear_attribute(skb_text_t* text, skb_text_range_t text_range, skb_attribute_t attribute);
 
 /**
  * Clears all attributes from specified range.
  * @param text pointer to the text to modify
  * @param text_range text range of attributes to remove (in utf-32 codepoints)
  */
-void skb_text_clear_all_attributes(skb_text_t* text, skb_text_range_t text_range);
+SKB_API void skb_text_clear_all_attributes(skb_text_t* text, skb_text_range_t text_range);
 
 /**
  * Add attribute to specified text range.
@@ -315,7 +315,7 @@ void skb_text_clear_all_attributes(skb_text_t* text, skb_text_range_t text_range
  * @param text_range text range to apply the attributes for (in utf-32 codepoints)
  * @param attribute attribute to add
  */
-void skb_text_add_attribute(skb_text_t* text, skb_text_range_t text_range, skb_attribute_t attribute);
+SKB_API void skb_text_add_attribute(skb_text_t* text, skb_text_range_t text_range, skb_attribute_t attribute);
 
 /**
  * Add attribute and payload to specified text range.
@@ -325,7 +325,7 @@ void skb_text_add_attribute(skb_text_t* text, skb_text_range_t text_range, skb_a
  * @param span_flags span flags to apply for the attribute, see skb_attribute_span_flags_t.
  * @param payload payload to apply for the attribute.
  */
-void skb_text_add_attribute_with_payload(skb_text_t* text, skb_text_range_t text_range, skb_attribute_t attribute, uint8_t span_flags, const skb_data_blob_t* payload);
+SKB_API void skb_text_add_attribute_with_payload(skb_text_t* text, skb_text_range_t text_range, skb_attribute_t attribute, uint8_t span_flags, const skb_data_blob_t* payload);
 
 /**
  * Signature of attribute iterator callback.
@@ -343,7 +343,7 @@ typedef void skb_attribute_run_iterator_func_t(const skb_text_t* text, skb_text_
  * @param callback function to call for each attribute run.
  * @param context context that is passed to the callback.
  */
-void skb_text_iterate_attribute_runs(const skb_text_t* text, skb_attribute_run_iterator_func_t* callback, void* context);
+SKB_API void skb_text_iterate_attribute_runs(const skb_text_t* text, skb_attribute_run_iterator_func_t* callback, void* context);
 
 /** @} */
 

--- a/readme.md
+++ b/readme.md
@@ -48,17 +48,28 @@ Skribidi just got started. There are bugs and the API is very likely to change.
 - Ensure CMake is in the user `PATH`
 - `mkdir build`
 - `cd build`
-- `cmake ..`
-- Build
+- Generate the build files:
+    - `cmake ..`
+- Compile:
 	- *Windows*: Open and build `build/skribidi.sln`
 	- *Linux*: use `cmake --build . -j$(nproc)`
 	- *macOS*: use `cmake --build . -j$(sysctl -n hw.ncpu)`
 
 When running the example or test, the working directory should be the build binary directory (`/build/bin`). On Windows, the example data direction is copied there and on Linux or macOS there's a symlink for the data directory.
 
+When generating the build files, you can provide options to using the `-D` flag (for example `cmake .. -D SKRIBIDI_UNIT_TESTS=OFF`). Skribidi provides a number of options:
+
+- **`BUILD_SHARED_LIBS`** determines whether Skribidi and it's dependencies are built as a static library or as a shared library. This is disabled by default, producing a static library.
+
+- **`SKRIBIDI_LIBRARY_TYPE`** is the library type to build only Skribidi as and doesn't effect Skribidi's dependencies. It must be a valid CMake library type. Set it to `STATIC` to build as a static library, `SHARED` to build as a shared library, or `OBJECT` to build as a CMake object library.
+
+- **`SKRIBIDI_EXAMPLE`** determines whether the examples are built along with the library. Disabled by default when Skribidi is build as a subproject of a larger CMake project.
+
+- **`SKRIBIDI_UNIT_TESTS`** determines whether the unit tests are build along with the library. Disabled by default when Skribidi is build as a subproject of a larger CMake project.
+
 ## Dependencies
 The project uses CMake, but you dont need to. If you handle dependecies yourself you can just add the
-`include` and `src` to your project and you're good to go. The CMake is used to fetch the right deps
+`include` and `src` to your project and you're good to go. If you are using Skdribidi as a shared library, you must define `SKB_DLL`, otherwise it must not be defined. The CMake is used to fetch the right deps
 and to build the examples and tests, making development simpler.
 
 - [Harfbuzz](https://github.com/harfbuzz/harfbuzz) - 11.0.0

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -182,6 +182,14 @@ if (MSVC)
 	target_sources(skribidi PRIVATE skribidi.natvis)
 endif()
 
+if (SKRIBIDI_BUILD_SHARED_LIBRARY)
+	target_compile_definitions(skribidi PRIVATE SKB_BUILD_DLL)
+
+	if (WIN32)
+		target_compile_definitions(skribidi INTERFACE SKB_DLL)
+	endif()
+endif()
+
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" PREFIX "src" FILES ${SKRIBIDI_SOURCE_FILES})
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/../include" PREFIX "include" FILES ${SKRIBIDI_API_FILES})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,7 +139,7 @@ set(SKRIBIDI_API_FILES
 )
 
 
-add_library(skribidi ${SKRIBIDI_SOURCE_FILES} ${SKRIBIDI_API_FILES})
+add_library(skribidi ${SKRIBIDI_LIBRARY_TYPE} ${SKRIBIDI_SOURCE_FILES} ${SKRIBIDI_API_FILES})
 
 target_include_directories(skribidi
   PUBLIC
@@ -150,12 +150,19 @@ target_include_directories(skribidi
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
+target_compile_definitions(skribidi
+  PRIVATE
+  	SKB_BUILD
+)
+
 set(CMAKE_DEBUG_POSTFIX "d")
 
 set_target_properties(skribidi PROPERTIES
 	C_STANDARD 17
     C_STANDARD_REQUIRED YES
     C_EXTENSIONS YES
+	C_VISIBILITY_PRESET hidden
+	VISIBILITY_INLINES_HIDDEN YES
     VERSION ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR}
 	DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -150,11 +150,6 @@ target_include_directories(skribidi
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-target_compile_definitions(skribidi
-  PRIVATE
-  	SKB_BUILD
-)
-
 set(CMAKE_DEBUG_POSTFIX "d")
 
 set_target_properties(skribidi PROPERTIES


### PR DESCRIPTION
I want to use Skribidi from C#, but that requires the library be built as a shared library. I have attempted to add support for that in this PR. With this setup, you can either use `-DBUILD_SHARED_LIBS=1` to build everything as a shared library or `-DSKRIBIDI_LIBRARY_TYPE=SHARED` to build only Skribidi itself as a shared library. I have tested the examples and tests with static linking and dynamic linking on Windows (MSVC) and Linux (MinGW cross compile and GCC).